### PR TITLE
Add ability to boot.py to boot all 4 L2CPUs at once

### DIFF
--- a/misc/README.md
+++ b/misc/README.md
@@ -1,0 +1,42 @@
+## Booting All 4 L2CPUs
+Each of the 4 L2CPUs require a different device tree
+1. L2CPU0 and 1 have a dedicated 4G DRAM tile each, so can use full 4G memory
+1. L2CPU2 and 3 share a 4G DRAM tile, so we must craft each L2CPU's device tree in a manner that they have no overlapping memory regions
+
+We need to make changes to the memory cell, and anything else that uses this memory cell (reserved memory, pmem region, network driver)
+
+`x280_l2cpu2.dts` allocates the first 2G of the memory region for this L2CPU (with appropriate changes to the pmem region)  
+`x280_l2cpu3.dts` allocates the last 2G of the memory region for this L2CPU (with appropriate changes to the pmem region)
+
+L2CPU 0 and 1 can use the `x280.dts` device tree from the parent folder
+
+
+To boot all 4 L2CPUs, do the following (can this be put into the justfile @jms?)
+
+```
+# Adjusted for FS of size 1200 MB
+     FS_ADDR="0x4000e5000000 0x4000e5000000 0x400065000000 0x4000e5000000"
+PAYLOAD_ADDR="0x400030000000 0x400030000000 0x400030000000 0x4000B0000000"
+ KERNEL_ADDR="0x400030200000 0x400030200000 0x400030200000 0x4000B0200000"
+    DTB_ADDR="0x400030100000 0x400030100000 0x400030100000 0x4000B0100000"
+
+PAYLOAD=<path-to-opensbi-fw_jump.bin>
+FS=<path-to-rootfs-img>
+KERNEL=<path-to-kernel-image>
+DTB="./x280.dtb ./x280.dtb ./x280_l2cpu2.dtb ./x280_l2cpu3.dtb"
+
+python boot.py --boot --opensbi_bin $PAYLOAD --opensbi_dst $PAYLOAD_ADDR --rootfs_bin $FS --rootfs_dst $FS_ADDR --kernel_bin $KERNEL --kernel_dst $KERNEL_ADDR --dtb_bin $DTB --dtb_dst $DTB_ADDR
+```
+
+All these args must be of the same length (which is the number of L2CPUs that are booted)
+--opensbi_dst
+--rootfs_dst
+--kernel_dst
+--dtb_dst
+--dtb_bin
+
+Since all 4 L2CPUs can boot the same kernel, rootfs, opensbi, we don't really need to change any of the other args. We just need to provide a different device tree and the locations to put these for each L2CPUs
+
+Note that the --l2cpu arg has been removed now
+
+Someone has to keep these device trees in sync with the one in the parent folder

--- a/misc/x280_l2cpu2.dts
+++ b/misc/x280_l2cpu2.dts
@@ -1,0 +1,166 @@
+/dts-v1/;
+
+/ {
+    #address-cells = <0x2>;
+    #size-cells = <0x2>;
+    compatible = "tt,whisper";
+    chosen {
+        bootargs = "rw console=hvc0 earlycon=sbi panic=-1 root=/dev/pmem0";
+    };
+    cpus {
+        #address-cells = <0x1>;
+        #size-cells = <0x0>;
+        timebase-frequency = <50000000>;
+        cpu@0 {
+            device_type = "cpu";
+            reg = <0x0>;
+            status = "okay";
+            compatible = "riscv";
+            riscv,isa = "rv64imafdcv_zicsr_zifencei_zfh_zba_zbb_zvfh_sscofpmf";
+            mmu-type = "riscv,sv57";
+            riscv,pmpregions = <0x10>;
+            riscv,pmpgranularity = <0x4>;
+            clock-frequency = <0x3B9ACA00>;
+            riscv,cboz-block-size = <0x40>;
+            cpu0_intc: interrupt-controller {
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+                #interrupt-cells = <1>;
+                #address-cells = <0>;
+            };
+        };
+        cpu@1 {
+            device_type = "cpu";
+            reg = <0x1>;
+            status = "okay";
+            compatible = "riscv";
+            riscv,isa = "rv64imafdcv_zicsr_zifencei_zfh_zba_zbb_zvfh_sscofpmf";
+            mmu-type = "riscv,sv57";
+            riscv,pmpregions = <0x10>;
+            riscv,pmpgranularity = <0x4>;
+            clock-frequency = <0x3B9ACA00>;
+            riscv,cboz-block-size = <0x40>;
+            cpu1_intc: interrupt-controller {
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+                #interrupt-cells = <1>;
+                #address-cells = <0>;
+            };
+        };
+        cpu@2 {
+            device_type = "cpu";
+            reg = <0x2>;
+            status = "okay";
+            compatible = "riscv";
+            riscv,isa = "rv64imafdcv_zicsr_zifencei_zfh_zba_zbb_zvfh_sscofpmf";
+            mmu-type = "riscv,sv57";
+            riscv,pmpregions = <0x10>;
+            riscv,pmpgranularity = <0x4>;
+            clock-frequency = <0x3B9ACA00>;
+            riscv,cboz-block-size = <0x40>;
+            cpu2_intc: interrupt-controller {
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+                #interrupt-cells = <1>;
+                #address-cells = <0>;
+            };
+        };
+        cpu@3 {
+            device_type = "cpu";
+            reg = <0x3>;
+            status = "okay";
+            compatible = "riscv";
+            riscv,isa = "rv64imafdcv_zicsr_zifencei_zfh_zba_zbb_zvfh_sscofpmf";
+            mmu-type = "riscv,sv57";
+            riscv,pmpregions = <0x10>;
+            riscv,pmpgranularity = <0x4>;
+            clock-frequency = <0x3B9ACA00>;
+            riscv,cboz-block-size = <0x40>;
+            cpu3_intc: interrupt-controller {
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+                #interrupt-cells = <1>;
+                #address-cells = <0>;
+            };
+        };
+
+
+
+    };
+    // This l2cpu uses first 2G of memory tile
+    memory@0 {
+        device_type = "memory";
+        reg = <0x4000 0x30000000 0x0 0x80000000>;
+    };
+
+    reserved-memory {
+        #address-cells = <2>;
+        #size-cells = <2>;
+        ranges;
+
+        // Don't map last 1200MB of memory
+        pmem: memory@400065000000 {
+            reg = <0x4000 0x65000000 0x0 0x4b000000>;
+            no-map;
+        };
+    };
+
+    // Last 1200MB of 2G Memory used for rootfs
+    // PMEM regions are not part of 'memory'
+    pmem@2896 {
+        compatible = "pmem-region";
+        reg = <0x4000 0x65000000 0x0 0x4b000000>;
+    };
+
+    soc {
+        #address-cells = <0x2>;
+        #size-cells = <0x2>;
+        compatible = "simple-bus";
+        ranges;
+
+        clint: timer@2000000 {
+            compatible = "riscv,clint0";
+            reg = <0x0 0x2000000 0x0 0x10000>;
+            // 3 = software interrupt
+            // 7 = timer interrupt
+            interrupts-extended = <&cpu0_intc 0x3>, <&cpu0_intc 0x7>, <&cpu1_intc 0x3>, <&cpu1_intc 0x7>,
+                                  <&cpu2_intc 0x3>, <&cpu2_intc 0x7>, <&cpu3_intc 0x3>, <&cpu3_intc 0x7>;
+        };
+
+        plic: interrupt-controller@c000000 {
+            compatible = "sifive,plic-1.0.0";
+            reg = <0x0 0x0c000000 0x0 0x04000000>,
+		  <0x0 0x2FF60000 0x0 0xF>; /* TT MSI catcher */
+            interrupts-extended = <&cpu0_intc 11>, <&cpu0_intc 9>, <&cpu1_intc 11>, <&cpu1_intc 9>,
+                                  <&cpu2_intc 11>, <&cpu2_intc 9>, <&cpu3_intc 11>, <&cpu3_intc 9>;
+            interrupt-controller;
+            #interrupt-cells = <1>;
+            #address-cells = <0>;
+            riscv,ndev = <128>;
+        };
+
+        ccache: cache-controller@2010000 {
+            compatible = "starfive,jh7100-ccache", "cache";
+            cache-block-size = <64>;
+            cache-level = <2>;
+            cache-sets = <2048>;
+            cache-size = <2097152>;
+            cache-unified;
+            interrupt-parent = <&plic>;
+            interrupts = <1>, <3>, <4>, <2>;
+            reg = <0x0 0x2010000 0x0 0x1000>;
+	        status = "disabled";
+        };
+
+        uart@2030000000 {
+            compatible = "ns16550a";
+            reg = <0x20 0x30000000 0x0 0x100>;
+            reg-shift = <0x2>;
+            reg-io-width = <0x4>;
+            clock-frequency = <0x2FAF080>;
+            current-speed = <460800>;
+            status = "disabled"; // no physical UART in scrappy
+        };
+
+    };
+};

--- a/misc/x280_l2cpu3.dts
+++ b/misc/x280_l2cpu3.dts
@@ -1,0 +1,166 @@
+/dts-v1/;
+
+/ {
+    #address-cells = <0x2>;
+    #size-cells = <0x2>;
+    compatible = "tt,whisper";
+    chosen {
+        bootargs = "rw console=hvc0 earlycon=sbi panic=-1 root=/dev/pmem0";
+    };
+    cpus {
+        #address-cells = <0x1>;
+        #size-cells = <0x0>;
+        timebase-frequency = <50000000>;
+        cpu@0 {
+            device_type = "cpu";
+            reg = <0x0>;
+            status = "okay";
+            compatible = "riscv";
+            riscv,isa = "rv64imafdcv_zicsr_zifencei_zfh_zba_zbb_zvfh_sscofpmf";
+            mmu-type = "riscv,sv57";
+            riscv,pmpregions = <0x10>;
+            riscv,pmpgranularity = <0x4>;
+            clock-frequency = <0x3B9ACA00>;
+            riscv,cboz-block-size = <0x40>;
+            cpu0_intc: interrupt-controller {
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+                #interrupt-cells = <1>;
+                #address-cells = <0>;
+            };
+        };
+        cpu@1 {
+            device_type = "cpu";
+            reg = <0x1>;
+            status = "okay";
+            compatible = "riscv";
+            riscv,isa = "rv64imafdcv_zicsr_zifencei_zfh_zba_zbb_zvfh_sscofpmf";
+            mmu-type = "riscv,sv57";
+            riscv,pmpregions = <0x10>;
+            riscv,pmpgranularity = <0x4>;
+            clock-frequency = <0x3B9ACA00>;
+            riscv,cboz-block-size = <0x40>;
+            cpu1_intc: interrupt-controller {
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+                #interrupt-cells = <1>;
+                #address-cells = <0>;
+            };
+        };
+        cpu@2 {
+            device_type = "cpu";
+            reg = <0x2>;
+            status = "okay";
+            compatible = "riscv";
+            riscv,isa = "rv64imafdcv_zicsr_zifencei_zfh_zba_zbb_zvfh_sscofpmf";
+            mmu-type = "riscv,sv57";
+            riscv,pmpregions = <0x10>;
+            riscv,pmpgranularity = <0x4>;
+            clock-frequency = <0x3B9ACA00>;
+            riscv,cboz-block-size = <0x40>;
+            cpu2_intc: interrupt-controller {
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+                #interrupt-cells = <1>;
+                #address-cells = <0>;
+            };
+        };
+        cpu@3 {
+            device_type = "cpu";
+            reg = <0x3>;
+            status = "okay";
+            compatible = "riscv";
+            riscv,isa = "rv64imafdcv_zicsr_zifencei_zfh_zba_zbb_zvfh_sscofpmf";
+            mmu-type = "riscv,sv57";
+            riscv,pmpregions = <0x10>;
+            riscv,pmpgranularity = <0x4>;
+            clock-frequency = <0x3B9ACA00>;
+            riscv,cboz-block-size = <0x40>;
+            cpu3_intc: interrupt-controller {
+                compatible = "riscv,cpu-intc";
+                interrupt-controller;
+                #interrupt-cells = <1>;
+                #address-cells = <0>;
+            };
+        };
+
+
+
+    };
+    // This l2cpu uses last 2G of memory tile
+    memory@0 {
+        device_type = "memory";
+        reg = <0x4000 0xb0000000 0x0 0x80000000>;
+    };
+
+    reserved-memory {
+        #address-cells = <2>;
+        #size-cells = <2>;
+        ranges;
+
+        // Don't map last 1200MB of memory
+        pmem: memory@4000e5000000 {
+            reg = <0x4000 0xe5000000 0x0 0x4b000000>;
+            no-map;
+        };
+    };
+
+    // Last 1200MB of 2G Memory used for rootfs
+    // PMEM regions are not part of 'memory'
+    pmem@2896 {
+        compatible = "pmem-region";
+        reg = <0x4000 0xe5000000 0x0 0x4b000000>;
+    };
+
+    soc {
+        #address-cells = <0x2>;
+        #size-cells = <0x2>;
+        compatible = "simple-bus";
+        ranges;
+
+        clint: timer@2000000 {
+            compatible = "riscv,clint0";
+            reg = <0x0 0x2000000 0x0 0x10000>;
+            // 3 = software interrupt
+            // 7 = timer interrupt
+            interrupts-extended = <&cpu0_intc 0x3>, <&cpu0_intc 0x7>, <&cpu1_intc 0x3>, <&cpu1_intc 0x7>,
+                                  <&cpu2_intc 0x3>, <&cpu2_intc 0x7>, <&cpu3_intc 0x3>, <&cpu3_intc 0x7>;
+        };
+
+        plic: interrupt-controller@c000000 {
+            compatible = "sifive,plic-1.0.0";
+            reg = <0x0 0x0c000000 0x0 0x04000000>,
+		  <0x0 0x2FF60000 0x0 0xF>; /* TT MSI catcher */
+            interrupts-extended = <&cpu0_intc 11>, <&cpu0_intc 9>, <&cpu1_intc 11>, <&cpu1_intc 9>,
+                                  <&cpu2_intc 11>, <&cpu2_intc 9>, <&cpu3_intc 11>, <&cpu3_intc 9>;
+            interrupt-controller;
+            #interrupt-cells = <1>;
+            #address-cells = <0>;
+            riscv,ndev = <128>;
+        };
+
+        ccache: cache-controller@2010000 {
+            compatible = "starfive,jh7100-ccache", "cache";
+            cache-block-size = <64>;
+            cache-level = <2>;
+            cache-sets = <2048>;
+            cache-size = <2097152>;
+            cache-unified;
+            interrupt-parent = <&plic>;
+            interrupts = <1>, <3>, <4>, <2>;
+            reg = <0x0 0x2010000 0x0 0x1000>;
+	        status = "disabled";
+        };
+
+        uart@2030000000 {
+            compatible = "ns16550a";
+            reg = <0x20 0x30000000 0x0 0x100>;
+            reg-shift = <0x2>;
+            reg-io-width = <0x4>;
+            clock-frequency = <0x2FAF080>;
+            current-speed = <460800>;
+            status = "disabled"; // no physical UART in scrappy
+        };
+
+    };
+};


### PR DESCRIPTION
PR makes the following changes

1. Removes `--l2cpu` arg. From now on, the number of l2cpus that are booted are determined by the number of args we pass to `--dtb_bin`
2. Made these args into a list instead of just a single arg:
--opensbi_dst
--rootfs_dst
--kernel_dst
--dtb_dst
--dtb_bin
We check that all of them are of the same length and between 1 and 4. This determines how many l2cpus we boot. 
So you could boot just l2cpu0(current behaviour), 2 of them (l2cpu 0,1) , 3 of them(l2cpu 0,1,2) or all 4 (l2cpu 0,1,2,3)
The rest of the args aren't changed cause the l2cpus can use the same kernel, rootfs and opensbi

3. Adds a readme in `misc` on how to do this. The boot command here could be put into the justfile
4. Adds special device trees for l2cpu2 and 3 since they share a dram tile need to use non-overlapping memory regions.


