### PR TITLE
build.sh: Enable HVC_RISCV_SBI in kernel config

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,11 +11,17 @@ if [[ $? -ne 0 ]] ; then
     exit 1
 fi
 
+export CROSS_COMPILE=riscv64-linux-gnu-
+export ARCH=riscv
+
 pushd $LINUX
 if [ ! -f ".config" ]; then
-  make CROSS_COMPILE=riscv64-linux-gnu- ARCH=riscv defconfig
+  make defconfig
+  ./scripts/config --enable NONPORTABLE
+  ./scripts/config --enable HVC_RISCV_SBI
+  make olddefconfig
 fi
-make CROSS_COMPILE=riscv64-linux-gnu- ARCH=riscv -j$(nproc)
+make -j$(nproc)
 popd
 
 pushd $SBI


### PR DESCRIPTION
Enable NONPORTABLE and HVC_RISCV_SBI in kernel config.  This is necessary for there to be console output. Without these options enabled, The boot log will contain "Warning: unable to open an initial console" with no further output.