### PR TITLE
build.sh: use just rather than bespoke commands

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,46 +1,8 @@
 #!/bin/bash
 
-export DTS=$PWD/x280.dts
-export DTB=$PWD/x280.dtb
+set -e
 
-export BASE_DIR=$HOME
+just build_all
 
-export LINUX_DIR=$BASE_DIR/linux
-export LINUX_REPO=https://github.com/tenstorrent/linux
-export LINUX_BRANCH=master
-
-export SBI_DIR=$BASE_DIR/opensbi
-export SBI_REPO=https://github.com/tenstorrent/opensbi.git
-export SBI_BRANCH=dfustini/wip/tt-bh-linux
-
-dtc $DTS > $DTB
-if [[ $? -ne 0 ]] ; then
-    echo "error: dtc failed to compile device tree source file"
-    exit 1
-fi
-
-export CROSS_COMPILE=riscv64-linux-gnu-
-export ARCH=riscv
-
-if [ ! -d "$LINUX_DIR" ]; then
-  git clone $LINUX_REPO
-fi
-
-pushd $LINUX_DIR
-git checkout $LINUX_BRANCH
-if [ ! -f ".config" ]; then
-  make defconfig
-  ./scripts/config --enable NONPORTABLE
-  ./scripts/config --enable HVC_RISCV_SBI
-  make olddefconfig
-fi
-make -j$(nproc)
-popd
-
-if [ ! -d "$SBI_DIR" ]; then
-  git clone https://github.com/tenstorrent/opensbi.git
-fi
-
-pushd $SBI_DIR
-git checkout $SBI_BRANCH
-CROSS_COMPILE=riscv64-linux-gnu- make FW_PIC=y FW_JUMP=y FW_JUMP_OFFSET=0x200000 FW_JUMP_FDT_OFFSET=0x100000  PLATFORM=generic
+# Call this over download_rootfs so it doesn't redownload the large rootfs if it's already there
+just _need_rootfs

--- a/run.sh
+++ b/run.sh
@@ -7,9 +7,9 @@ PAYLOAD_ADDR="0x400030000000"
     DTB_ADDR="0x400030100000"
 
 DTB=$PWD/x280.dtb
-KERNEL=$HOME/linux/arch/riscv/boot/Image
-PAYLOAD=$HOME/opensbi/build/platform/generic/firmware/fw_jump.bin
-FS=$HOME/rootfs.ext4
+KERNEL=$PWD/linux/arch/riscv/boot/Image
+PAYLOAD=$PWD/opensbi/build/platform/generic/firmware/fw_jump.bin
+FS=$PWD/rootfs.ext4
 CONSOLE=blackhole-thing/build/console
 
 python boot.py --boot --opensbi_bin $PAYLOAD --opensbi_dst $PAYLOAD_ADDR --rootfs_bin $FS --rootfs_dst $FS_ADDR --kernel_bin $KERNEL --kernel_dst $KERNEL_ADDR --dtb_bin $DTB --dtb_dst $DTB_ADDR


### PR DESCRIPTION
This moves the logic out of build.sh to use just.

Move the build from $HOME to $PWD.

run.sh is adjusted but untested