### PR TITLE
Add network program that uses new TLB API

### DIFF
--- a/console/Makefile
+++ b/console/Makefile
@@ -1,6 +1,7 @@
 all: ioctl.h
 	g++ -O2 console.cpp l2cpu.cpp tlb.cpp -o console
 	g++ -O2 test.cpp l2cpu.cpp tlb.cpp -o test
+	g++ -O2 network.cpp l2cpu.cpp tlb.cpp -pthread -Wall -lvdeslirp -lslirp -o network
 
 ioctl.h:
 	@TT_VERSION=$$(modinfo tenstorrent | grep -i ^version | awk '{print $$2}'); \
@@ -14,4 +15,4 @@ ioctl.h:
 	fi
 
 clean:
-	rm -f ioctl.h console test
+	rm -f ioctl.h console test network

--- a/console/libvdeslirp.h
+++ b/console/libvdeslirp.h
@@ -1,0 +1,7 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include <slirp/libvdeslirp.h>
+#ifdef __cplusplus
+}
+#endif

--- a/console/network.cpp
+++ b/console/network.cpp
@@ -1,0 +1,202 @@
+#include <stdint.h>
+#include <string.h>
+#include <slirp/libslirp.h>
+#include <sys/time.h>
+#include <sys/select.h>
+#include <signal.h>
+#include <inttypes.h>
+#include <iostream>
+#include <cassert>
+#include <getopt.h>
+
+#include "l2cpu.h"
+#include "libvdeslirp.h"
+
+#define MTU 1500 // MTU (Ignoring ethernet header) that is set for adapter = 1500
+#define PACKET_SIZE 1514 // MTU + ethernet header size = 1514
+
+#define PMEM_REGION_SIZE (1200ULL*1024*1024)
+#define TTETH_SHM_REGION_OFFSET (PMEM_REGION_SIZE + (2ULL*1024*1024))
+
+#define X280_REGISTERS 0xFFFFF7FEFFF10000ULL
+#define INTERRUPT_NUMBER 33
+
+#define BUFFER_SIZE 500
+
+#define MAGIC 0x4D13ED8246A0f856ULL
+
+struct packet{
+    uint32_t len;
+    char data[PACKET_SIZE];
+};
+
+struct one_side_buffer{
+    uint32_t location_sent;
+    uint32_t location_rcvd;
+    struct packet buffer[BUFFER_SIZE];
+};
+
+struct shared_data{
+    uint64_t magic;
+    uint32_t interrupts;
+    struct one_side_buffer send;
+    struct one_side_buffer recv;
+};
+
+
+int run_once(int l2cpu_idx){
+
+    L2CPU l2cpu(l2cpu_idx);
+
+    // Assumes that 2M memory region is at the region just before the beginning of th pmem, which itself is at the end of the dram
+    uint64_t address = l2cpu.get_starting_address() + l2cpu.get_memory_size() - TTETH_SHM_REGION_OFFSET;
+
+    auto window = l2cpu.get_persistent_2M_tlb_window(address);
+    struct shared_data* base = reinterpret_cast<struct shared_data*>(window->get_window());
+
+    uint64_t interrupt_address = X280_REGISTERS + 0x404; // X280 Global Interrupts Register Bits 31 to 0
+    // For some reason, interrupts 6->9 don't work for this even though I think they should
+    // Only interrupts 0->5 are reserved, don't know if 6->9 are also connected to something else
+    // Interrupts are triggered by setting bit INTERRUPT_NUMBER-5 in the register referenced above
+    assert(INTERRUPT_NUMBER >= 10 && INTERRUPT_NUMBER <= 36);
+
+    memset(&(base->send), 0, sizeof(struct one_side_buffer));
+    memset(&(base->recv), 0, sizeof(struct one_side_buffer));
+    struct one_side_buffer* send = &(base->send);
+    struct one_side_buffer* recv = &(base->recv);
+
+    SlirpConfig slirpcfg;
+    slirpcfg.if_mru = PACKET_SIZE;
+    slirpcfg.if_mtu = PACKET_SIZE;
+    struct vdeslirp *myslirp;
+    vdeslirp_init(&slirpcfg, VDE_INIT_DEFAULT);
+    myslirp = vdeslirp_open(&slirpcfg);
+
+    // Port Forwarding for SSH
+    struct in_addr host, guest;
+    inet_aton("127.0.0.1", &host);
+    inet_aton("10.0.2.15", &guest);
+    vdeslirp_add_fwd(myslirp, 0, host, 2222+l2cpu_idx, guest, 22);
+
+    int len, ret_code;
+    int slirp_fd = vdeslirp_fd(myslirp);
+    void *buf=malloc(PACKET_SIZE);
+    struct packet *location;
+
+    // Prevent writing into a closed socket (which may happen after a TCP reset) 
+    // (which causes a SIGPIPE) from killing the process
+    signal(SIGPIPE, SIG_IGN);
+    // Unused variable, might use it for something in the future so leaving it around
+    // bool irq_asserted = false;
+
+    while (true){
+        if (base->magic != MAGIC) {
+            printf("Magic was %" PRIu64 ", not %lld trying again\n", base->magic, MAGIC);
+            break;
+        }
+        struct timeval tv;
+        fd_set rfds;
+        FD_ZERO(&rfds);
+        FD_SET(slirp_fd, &rfds);
+        tv.tv_sec = 0;
+        tv.tv_usec = 1;
+
+        if (base->interrupts == 1){
+            l2cpu.write32(interrupt_address, l2cpu.read32(interrupt_address) & ~(1 << (INTERRUPT_NUMBER - 5)));
+            // irq_asserted = false;
+            base->interrupts=0;
+        }
+        ret_code = select(slirp_fd + 1, &rfds, NULL, NULL, &tv);
+        if ((send->location_rcvd != ((send->location_sent + 1)%BUFFER_SIZE)) && ret_code > 0){
+            len = vdeslirp_recv(myslirp, buf, PACKET_SIZE);
+
+            uint32_t location_sent = send->location_sent;
+
+            location = send->buffer + location_sent;
+            memcpy(location->data, buf, len);
+            location->len = len;
+
+            // Memory barrier to ensure data is written before updating the pointer
+            __sync_synchronize();
+
+            send->location_sent = (location_sent + 1) % BUFFER_SIZE; // pointer to data
+            // Set the (Interrupt_number -5)th bit in the X280_Global_Interrupts_31_0 register to trigger an interrupt
+            // Something about first 6 interrupts being reserved for other uses
+            if(base->interrupts==0){
+                l2cpu.write32(interrupt_address, (1 << (INTERRUPT_NUMBER - 5)));
+                // irq_asserted = true;
+            }
+        }
+        if (recv->location_rcvd!=recv->location_sent){
+            uint32_t location_rcvd = recv->location_rcvd;
+
+            location = recv->buffer + location_rcvd;
+            len = location->len;
+            memcpy(buf, location->data, len);
+
+            // Memory barrier to ensure data is read before updating the pointer
+            __sync_synchronize();
+
+            recv->location_rcvd = (location_rcvd + 1)%BUFFER_SIZE;
+
+            ret_code = vdeslirp_send(myslirp, buf, len);
+            if (ret_code < 0){
+                perror("vdeslirp_send failed");
+                break;
+            }
+        }
+    }
+
+    vdeslirp_close(myslirp);
+    free(buf);
+    return 0;
+}
+
+int main(int argc, char **argv){
+    int l2cpu=0;
+    const char* const short_opts = "l:h";
+    const option long_opts[] = {
+            {"l2cpu", required_argument, nullptr, 'l'},
+            {"help", no_argument, nullptr, 'h'},
+            {nullptr, no_argument, nullptr, 0}
+    };
+
+    while (true)
+    {
+        const auto opt = getopt_long(argc, argv, short_opts, long_opts, nullptr);
+
+        if (-1 == opt)
+            break;
+
+        switch (opt)
+        {
+        case 'l':
+            l2cpu = std::stoi(optarg);
+            break;
+
+        case 'h': // -h or --help
+        case '?': // Unrecognized option
+        default:
+            std::cout <<
+            "--l2cpu <l>:         L2CPU to attach to\n"
+            "--help:              Show help\n";
+            exit(1);
+        }
+    }
+
+    if (l2cpu < 0 || l2cpu > 3){
+        std::cerr<<"l2cpu must be one of 0,1,2,3"<<"\n";
+        exit(1);
+    }
+
+    while (true){
+        /*
+        We call run_once in a loop
+        If the chip resets or the MAGIC value disappears,
+        we sleep for a bit and try setting everything up again
+        */
+        run_once(l2cpu);
+        std::cout<<"Sleeping for a bit and trying again"<<"\n";
+        usleep(100000);
+    }
+}

--- a/justfile
+++ b/justfile
@@ -84,7 +84,7 @@ clean_downloads:
 # Recipes that install packages
 
 # Install all packages
-install_all: apt_update install_kernel_pkgs install_toolchain_pkgs install_tool_pkgs
+install_all: apt_update install_kernel_pkgs install_toolchain_pkgs install_tool_pkgs install_libs
 
 sudo := 'sudo'
 
@@ -107,6 +107,9 @@ install_qemu: (install 'qemu-system-misc qemu-utils qemu-system-common qemu-syst
 
 # Install tools
 install_tool_pkgs: (install 'device-tree-compiler xz-utils python3 unzip')
+
+# Install libraries for compiling
+install_libs: (install 'libvdeslirp-dev libslirp-dev')
 
 #################################
 # Recipes that clone git trees


### PR DESCRIPTION
Adds network.cpp that can be called in this manner
```
./network --l2cpu $L2CPUID
```
If no arg is specified, it uses L2CPU 0.

Network program sets up port-forwarding for SSH, so port 2222 on host is forwarded to port 22 on the x280.