### PR TITLE
x280.dts: update from linux tt-blackhole branch

### DIFF
--- a/x280.dts
+++ b/x280.dts
@@ -1,165 +1,145 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
 /dts-v1/;
 
 / {
-    #address-cells = <0x2>;
-    #size-cells = <0x2>;
-    compatible = "tt,whisper";
-    chosen {
-        bootargs = "rw console=hvc0 earlycon=sbi panic=-1 root=/dev/pmem0";
-    };
-    cpus {
-        #address-cells = <0x1>;
-        #size-cells = <0x0>;
-        timebase-frequency = <50000000>;
-        cpu@0 {
-            device_type = "cpu";
-            reg = <0x0>;
-            status = "okay";
-            compatible = "riscv";
-            riscv,isa = "rv64imafdcv_zicsr_zifencei_zfh_zba_zbb_zvfh_sscofpmf";
-            mmu-type = "riscv,sv57";
-            riscv,pmpregions = <0x10>;
-            riscv,pmpgranularity = <0x4>;
-            clock-frequency = <0x3B9ACA00>;
-            riscv,cboz-block-size = <0x40>;
-            cpu0_intc: interrupt-controller {
-                compatible = "riscv,cpu-intc";
-                interrupt-controller;
-                #interrupt-cells = <1>;
-                #address-cells = <0>;
-            };
-        };
-        cpu@1 {
-            device_type = "cpu";
-            reg = <0x1>;
-            status = "okay";
-            compatible = "riscv";
-            riscv,isa = "rv64imafdcv_zicsr_zifencei_zfh_zba_zbb_zvfh_sscofpmf";
-            mmu-type = "riscv,sv57";
-            riscv,pmpregions = <0x10>;
-            riscv,pmpgranularity = <0x4>;
-            clock-frequency = <0x3B9ACA00>;
-            riscv,cboz-block-size = <0x40>;
-            cpu1_intc: interrupt-controller {
-                compatible = "riscv,cpu-intc";
-                interrupt-controller;
-                #interrupt-cells = <1>;
-                #address-cells = <0>;
-            };
-        };
-        cpu@2 {
-            device_type = "cpu";
-            reg = <0x2>;
-            status = "okay";
-            compatible = "riscv";
-            riscv,isa = "rv64imafdcv_zicsr_zifencei_zfh_zba_zbb_zvfh_sscofpmf";
-            mmu-type = "riscv,sv57";
-            riscv,pmpregions = <0x10>;
-            riscv,pmpgranularity = <0x4>;
-            clock-frequency = <0x3B9ACA00>;
-            riscv,cboz-block-size = <0x40>;
-            cpu2_intc: interrupt-controller {
-                compatible = "riscv,cpu-intc";
-                interrupt-controller;
-                #interrupt-cells = <1>;
-                #address-cells = <0>;
-            };
-        };
-        cpu@3 {
-            device_type = "cpu";
-            reg = <0x3>;
-            status = "okay";
-            compatible = "riscv";
-            riscv,isa = "rv64imafdcv_zicsr_zifencei_zfh_zba_zbb_zvfh_sscofpmf";
-            mmu-type = "riscv,sv57";
-            riscv,pmpregions = <0x10>;
-            riscv,pmpgranularity = <0x4>;
-            clock-frequency = <0x3B9ACA00>;
-            riscv,cboz-block-size = <0x40>;
-            cpu3_intc: interrupt-controller {
-                compatible = "riscv,cpu-intc";
-                interrupt-controller;
-                #interrupt-cells = <1>;
-                #address-cells = <0>;
-            };
-        };
+	model = "Tenstorrent Blackhole P100";
+	compatible = "tenstorrent,blackhole-p100", "tenstorrent,blackhole";
 
+	#address-cells = <2>;
+	#size-cells = <2>;
 
+	chosen {
+		bootargs = "rw console=hvc0 earlycon=sbi panic=-1 root=/dev/pmem0";
+	};
 
-    };
-    memory@0 {
-        device_type = "memory";
-        reg = <0x4000 0x30000000 0x1 0x00000000>;
-    };
+	cpus {
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+		timebase-frequency = <50000000>;
 
-    reserved-memory {
-        #address-cells = <2>;
-        #size-cells = <2>;
-        ranges;
+		cpu@0 {
+			compatible = "sifive,x280", "sifive,rocket0", "riscv";
+			device_type = "cpu";
+			reg = <0>;
+			mmu-type = "riscv,sv57";
+			riscv,isa = "rv64imafdcv_zicsr_zifencei_zfh_zba_zbb_sscofpmf";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "zicsr",
+					       "zifencei", "zfh", "zba", "zbb", "sscofpmf";
+			clock-frequency = <0x3B9ACA00>;
+			riscv,cboz-block-size = <0x40>;
+			status = "okay";
+			cpu0_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
 
-        // Don't map last 1200MB of memory
-        pmem: memory@4000e5000000 {
-            reg = <0x4000 0xe5000000 0x0 0x4b000000>;
-            no-map;
-        };
-    };
+		cpu@1 {
+			compatible = "sifive,x280", "sifive,rocket0", "riscv";
+			device_type = "cpu";
+			reg = <1>;
+			mmu-type = "riscv,sv57";
+			riscv,isa = "rv64imafdcv_zicsr_zifencei_zfh_zba_zbb_sscofpmf";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "zicsr",
+					       "zifencei", "zfh", "zba", "zbb", "sscofpmf";
+			clock-frequency = <0x3B9ACA00>;
+			riscv,cboz-block-size = <0x40>;
+			status = "okay";
+			cpu1_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
 
-    // Last 1200MB of 4G Memory used for rootfs
-    // PMEM regions are not part of 'memory'
-    pmem@2896 {
-        compatible = "pmem-region";
-        reg = <0x4000 0xe5000000 0x0 0x4b000000>;
-    };
+		cpu@2 {
+			compatible = "sifive,x280", "sifive,rocket0", "riscv";
+			device_type = "cpu";
+			reg = <2>;
+			mmu-type = "riscv,sv57";
+			riscv,isa = "rv64imafdcv_zicsr_zifencei_zfh_zba_zbb_sscofpmf";
+			riscv,isa-base = "rv64i";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "zicsr",
+					       "zifencei", "zfh", "zba", "zbb", "sscofpmf";
+			clock-frequency = <0x3B9ACA00>;
+			riscv,cboz-block-size = <0x40>;
+			status = "okay";
+			cpu2_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
 
-    soc {
-        #address-cells = <0x2>;
-        #size-cells = <0x2>;
-        compatible = "simple-bus";
-        ranges;
+		cpu@3 {
+			compatible = "sifive,x280", "sifive,rocket0", "riscv";
+			device_type = "cpu";
+			reg = <3>;
+			mmu-type = "riscv,sv57";
+			riscv,isa-base = "rv64i";
+			riscv,isa = "rv64imafdcv_zicsr_zifencei_zfh_zba_zbb_sscofpmf";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "v", "zicsr",
+					       "zifencei", "zfh", "zba", "zbb", "sscofpmf";
+			clock-frequency = <0x3B9ACA00>;
+			riscv,cboz-block-size = <0x40>;
+			status = "okay";
+			cpu3_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+	};
 
-        clint: timer@2000000 {
-            compatible = "riscv,clint0";
-            reg = <0x0 0x2000000 0x0 0x10000>;
-            // 3 = software interrupt
-            // 7 = timer interrupt
-            interrupts-extended = <&cpu0_intc 0x3>, <&cpu0_intc 0x7>, <&cpu1_intc 0x3>, <&cpu1_intc 0x7>,
-                                  <&cpu2_intc 0x3>, <&cpu2_intc 0x7>, <&cpu3_intc 0x3>, <&cpu3_intc 0x7>;
-        };
+	memory@0 {
+		device_type = "memory";
+		reg = <0x4000 0x30000000 0x1 0x00000000>; /* 4 GB */
+	};
 
-        plic: interrupt-controller@c000000 {
-            compatible = "sifive,plic-1.0.0";
-            reg = <0x0 0x0c000000 0x0 0x04000000>,
-		  <0x0 0x2FF60000 0x0 0xF>; /* TT MSI catcher */
-            interrupts-extended = <&cpu0_intc 11>, <&cpu0_intc 9>, <&cpu1_intc 11>, <&cpu1_intc 9>,
-                                  <&cpu2_intc 11>, <&cpu2_intc 9>, <&cpu3_intc 11>, <&cpu3_intc 9>;
-            interrupt-controller;
-            #interrupt-cells = <1>;
-            #address-cells = <0>;
-            riscv,ndev = <128>;
-        };
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+		pmem: memory@4000e5000000 {
+			reg = <0x4000 0xe5000000 0x0 0x4b000000>;
+			no-map;
+		};
+	};
 
-        ccache: cache-controller@2010000 {
-            compatible = "starfive,jh7100-ccache", "cache";
-            cache-block-size = <64>;
-            cache-level = <2>;
-            cache-sets = <2048>;
-            cache-size = <2097152>;
-            cache-unified;
-            interrupt-parent = <&plic>;
-            interrupts = <1>, <3>, <4>, <2>;
-            reg = <0x0 0x2010000 0x0 0x1000>;
-	        status = "disabled";
-        };
+	pmem@4000e5000000 {
+		compatible = "pmem-region";
+		reg = <0x4000 0xe5000000 0x0 0x4b000000>; /* 1.2 GB */
+	};
 
-        uart@2030000000 {
-            compatible = "ns16550a";
-            reg = <0x20 0x30000000 0x0 0x100>;
-            reg-shift = <0x2>;
-            reg-io-width = <0x4>;
-            clock-frequency = <0x2FAF080>;
-            current-speed = <460800>;
-            status = "disabled"; // no physical UART in scrappy
-        };
+	soc {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		compatible = "simple-bus";
+		ranges;
 
-    };
+		clint0: timer@2000000 {
+			compatible = "tenstorrent,blackhole-clint", "sifive,clint0";
+			reg = <0x0 0x2000000 0x0 0x10000>;
+			interrupts-extended = <&cpu0_intc 0x3>, <&cpu0_intc 0x7>,
+					      <&cpu1_intc 0x3>, <&cpu1_intc 0x7>,
+					      <&cpu2_intc 0x3>, <&cpu2_intc 0x7>,
+					      <&cpu3_intc 0x3>, <&cpu3_intc 0x7>;
+		};
+
+		plic0: interrupt-controller@c000000 {
+			compatible = "tenstorrent,blackhole-plic", "sifive,plic-1.0.0";
+			reg = <0x0 0x0c000000 0x0 0x04000000>;
+			interrupts-extended = <&cpu0_intc 11>, <&cpu0_intc 9>,
+					      <&cpu1_intc 11>, <&cpu1_intc 9>,
+					      <&cpu2_intc 11>, <&cpu2_intc 9>,
+					      <&cpu3_intc 11>, <&cpu3_intc 9>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			#address-cells = <0>;
+			riscv,ndev = <128>;
+		};
+	};
 };


### PR DESCRIPTION
Update device tree file to match [arch/riscv/boot/dts/tenstorrent](https://github.com/tenstorrent/linux/tree/tt-blackhole/arch/riscv/boot/dts/tenstorrent) in the [tt-blackhole branch](https://github.com/tenstorrent/linux/tree/tt-blackhole) of the tenstorrent linux repo.  It is able to pass W=1 dtbs_check without warnings.

This kernel branch has the dts structured such that blackhole-p100.dts includes blackhole.dtsi. Both files were merged together to form x280.dts in this commit to be compatible with the existing CI flow.

In the future, the dtb can pulled from CI in the tenstorrent linux repo.