### PR TITLE
ci: Export github.run_id as CI_JOB_ID for the kernel build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      CI_JOB_ID: ${{ github.run_id }}
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
From the github docs:
  A unique number for each workflow run within a repository. This number
  does not change if you re-run the workflow run.

Before:
> Setting LOCALVERSION to tt-defconfig-runner

After:
> Setting LOCALVERSION to tt-defconfig-ci15111103246