### PR TITLE
Make the python detection logic more robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,8 @@ endif
 
 # Default to the pipx python so we get pyluwen for running boot.py
 # Set TT_PYTHON in your environment to point to your own venv if you prefer
-# TODO: Make this better
-ifdef TT_PYTHON
-    PYTHON := $(TT_PYTHON)
-else
-    PYTHON := $(HOME)/.local/share/pipx/venvs/tt-smi/bin/python3
+ifndef TT_PYTHON
+    TT_PYTHON := ./ttsmi-python
 endif
 
 # Use bash as the shell
@@ -61,8 +58,8 @@ help:
 # Recipes that run things
 
 # Boot the Blackhole RISC-V CPU
-boot: _need_linux _need_opensbi _need_dtb _need_rootfs _need_python _need_ttkmd _need_luwen
-	$(PYTHON) boot.py --boot --opensbi_bin fw_jump.bin --opensbi_dst 0x400030000000 --rootfs_bin rootfs.ext4 --rootfs_dst 0x4000e5000000 --kernel_bin Image --kernel_dst 0x400030200000 --dtb_bin blackhole-p100.dtb --dtb_dst 0x400030100000
+boot: _need_linux _need_opensbi _need_dtb _need_rootfs _need_python _need_luwen
+	$(TT_PYTHON) boot.py --boot --opensbi_bin fw_jump.bin --opensbi_dst 0x400030000000 --rootfs_bin rootfs.ext4 --rootfs_dst 0x4000e5000000 --kernel_bin Image --kernel_dst 0x400030200000 --dtb_bin blackhole-p100.dtb --dtb_dst 0x400030100000
 	./console/tt-bh-linux
 
 # Run tt-smi
@@ -360,10 +357,11 @@ define _need_prog =
 endef
 
 # _need_pylib: Check if a python package exists, and if not tell the user how to install it
+# NB. This uses TT_PYTHON.
 # args: python-package action-name target
 define _need_pylib =
     @$(SHELL_VERBOSE) \
-    if ! echo -e "import sys\ntry:\n\timport $(1)\nexcept ImportError:\n\tsys.exit(1)" | $(PYTHON); then \
+    if ! echo -e "import sys\ntry:\n\timport $(1)\nexcept ImportError:\n\tsys.exit(1)" | $(TT_PYTHON) > /dev/null; then \
         echo -e "\e[31mError: missing python '$(1)', $(2) it with \e[32m$(3)\e[0m"; \
         exit 1; \
     fi

--- a/ttsmi-python
+++ b/ttsmi-python
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Find the python interpreter in the pipx tt-smi venv and run it
+# Use `make install_tool_pkgs install_ttsmi` to install it.
+
+set -eo pipefail
+
+if ! command -v pipx > /dev/null; then
+    echo -e '\e[31mError: pipx is not installed, install it with \e[32mmake install_tool_pkgs\e[0m'
+    exit 1
+fi
+
+# pipx environment is only available in version >= 1.1.0
+rc=0
+pipx environment --value PIPX_LOCAL_VENVS > /dev/null 2>&1 || rc=1
+if [ $rc -eq 0 ]; then
+    dir=$(pipx environment --value PIPX_LOCAL_VENVS)
+else
+    # Find it manually
+    dir=$HOME/.local/share/pipx/venvs
+    if [ ! -d $dir ]; then
+        dir=$HOME/.local/pipx/venvs
+    fi
+fi
+
+if [ ! -d "$dir" ]; then
+    echo -e '\e[31mError: pipx venvs directory not found\e[0m'
+    exit 1
+fi
+
+TTSMI_DIR="$dir/tt-smi"
+if [ ! -d "$TTSMI_DIR" ]; then
+        echo -e '\e[31mError: tt-smi not found, install it with \e[32mmake install_ttsmi\e[0m'
+        exit 1
+fi
+
+PYTHON="$TTSMI_DIR/bin/python3"
+
+if [ ! -x "$PYTHON" ]; then
+        echo -e '\e[31mError: tt-smi python not found/executable\e[0m'
+        exit 1
+fi
+
+exec $PYTHON "$@"


### PR DESCRIPTION
The current logic hardcodes the pipx path, but different pipx versions store the venvs in different places.

Reported by @tt-fustini on Ubuntu 22.04 as:
```
(.venv) dfustini@rvsw-bh-01:~/tt-bh-linux$ just boot
error: Recipe `_need_pylib` with shebang `#!/home/dfustini/.local/share/pipx/venvs/tt-smi/bin/python3` execution error: No such file or directory (os error 2)
```

Add a script that wraps the logic to find the tt-smi python.

We might drop pipx entirely in future, but this at least makes it work for now.