### PR TITLE
Add Linux-syscall-note to ioctl.h

### DIFF
--- a/console/ioctl.h
+++ b/console/ioctl.h
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-License-Identifier: GPL-2.0-only WITH Linux-syscall-note
 
 #ifndef TTDRIVER_IOCTL_H_INCLUDED
 #define TTDRIVER_IOCTL_H_INCLUDED


### PR DESCRIPTION
Adding updated ioctl.h from KMD with linux-syscall-note in SPDX header. https://github.com/tenstorrent/tt-kmd/pull/63