### PR TITLE
build-image.sh: add btop and ninvaders

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -57,7 +57,7 @@ trap cleanup EXIT
 
 info "Installing system with debootstrap"
 mkdir -p $CACHE
-PACKAGES=sudo,openssh-server,systemd-timesyncd,vim,python3,make,gcc,libc6-dev,neowofetch,systemd-resolved,dbus
+PACKAGES=sudo,openssh-server,systemd-timesyncd,vim,python3,make,gcc,libc6-dev,neowofetch,systemd-resolved,dbus,btop,ninvaders
 debootstrap --cache-dir $CACHE --include $PACKAGES --arch riscv64 trixie $MOUNT http://deb.debian.org/debian
 
 info "Mounting filesystems"


### PR DESCRIPTION
CI created new image with btop and ninvaders:
https://github.com/tenstorrent/tt-bh-linux/actions/runs/15287579611

btop works okay on console and ssh:
<img width="1381" alt="Screenshot 2025-05-27 at 4 59 55 PM" src="https://github.com/user-attachments/assets/e4fe298c-e1c0-4816-89ad-35c25de42fdc" />

ninvaders doesn't seem to work over the console but it does work okay over ssh:
<img width="1381" alt="Screenshot 2025-05-27 at 5 00 56 PM" src="https://github.com/user-attachments/assets/dc0f64e6-798e-4a3b-be19-9687c9510008" />
