### PR TITLE
ci: automate release artifact upload and release notes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [ $default-branch ]
+  release:
+    types: [created]
 
 jobs:
   build:
@@ -24,9 +26,53 @@ jobs:
     - name: Clone Linux and OpenSBI
       run: make clone_all
 
-    - name: Build Linux, OpenSBI and device tree
+    - name: Build Linux and device tree
       run: |
-        make build_all
+        make build_linux
+
+    - name: Build OpenSBI
+      run: |
+        make build_opensbi
+
+    - name: Generate release notes
+      run: |
+        if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          # For tags, show changes since last non-RC release
+          echo -e "## Release ${{ github.ref_name }}\n" > release-notes.md
+          PREV_TAG=$(git tag --list 'v*' --sort=-creatordate | grep -v -E 'rc|RC' | grep -v "^${{ github.ref_name }}$" | head -n1)
+          if [ -n "$PREV_TAG" ]; then
+            echo -e "\n## Changes since $PREV_TAG:\n" >> release-notes.md
+            git shortlog "$PREV_TAG"..HEAD >> release-notes.md
+          fi
+        elif [[ "${{ github.ref }}" == refs/pull/* ]]; then
+          # For PRs, show changes in this PR
+          echo -e "## Pull Request #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}\n" > release-notes.md
+          echo -e "\n## Changes in this PR:\n" >> release-notes.md
+          git shortlog ${{ github.event.pull_request.base.sha }}..HEAD >> release-notes.md
+        else
+          # For branches, show changes since last tag
+          echo -e "## Branch Build: ${{ github.ref_name }}\n" > release-notes.md
+          LATEST_TAG=$(git tag --list 'v*' --sort=-creatordate | head -n1)
+          if [ -n "$LATEST_TAG" ]; then
+            echo -e "\n## Changes since $LATEST_TAG:\n" >> release-notes.md
+            git shortlog "$LATEST_TAG"..HEAD >> release-notes.md
+          else
+            echo -e "\n## Recent changes:\n" >> release-notes.md
+            git shortlog --max-count 20 >> release-notes.md
+          fi
+        fi
+
+        echo -e "\n## Artifacts included:" >> release-notes.md
+        echo "- Image" >> release-notes.md
+        echo "- fw_jump.bin" >> release-notes.md
+        echo "- blackhole-p100.dtb" >> release-notes.md
+        echo "- tt-bh-linux.zip (Image, fw_jump.bin, blackhole-p100.dtb)" >> release-notes.md
+        echo "- tt-bh-disk-image.zip (debian-riscv64.img)" >> release-notes.md
+        echo -e "\nBuilt by CI run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> release-notes.md
+
+    - name: Zip Linux build artifacts
+      run: |
+        zip -j tt-bh-linux.zip Image fw_jump.bin blackhole-p100.dtb
 
     - name: Archive artifacts
       uses: actions/upload-artifact@v4
@@ -37,12 +83,49 @@ jobs:
           fw_jump.bin
           blackhole-p100.dtb
 
+    - name: Archive zipped Linux artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: tt-bh-linux-zip
+        path: tt-bh-linux.zip
+
+    - name: Archive release notes
+      uses: actions/upload-artifact@v4
+      continue-on-error: true
+      with:
+        name: release-notes
+        path: release-notes.md
+
+  generate_rootfs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update -qq && sudo apt-get install -qq qemu-user-static qemu-utils debootstrap
+
+    - name: Build disk image
+      run: |
+        sudo ./build-image.sh
+
+    - name: Zip disk image
+      run: |
+        zip -j tt-bh-disk-image.zip debian-riscv64.img
+
+    - name: Archive zipped disk image
+      uses: actions/upload-artifact@v4
+      with:
+        name: tt-bh-disk-image-zip
+        path: tt-bh-disk-image.zip
+
   upload_release_artifacts:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build]
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'release'
+    needs: [build, generate_rootfs]
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: tt-beta-ubuntu-2204-small
 
     steps:
     - uses: actions/checkout@v4
@@ -52,29 +135,32 @@ jobs:
       with:
         name: tt-bh-linux
 
-    - name: Upload packages to release
+    - name: Download zipped Linux artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: tt-bh-linux-zip
+
+    - name: Download zipped disk image artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: tt-bh-disk-image-zip
+
+    - name: Download release notes artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: release-notes
+
+    - name: Create Release
       run: |
-        gh release upload ${{ github.ref_name }} Image fw_jump.bin blackhole-p100.dtb
+        if ! gh release view "${{ github.ref_name }}" > /dev/null 2>&1; then
+          gh release create "${{ github.ref_name }}" --notes-file release-notes.md
+        fi
       env:
         GITHUB_TOKEN: ${{ github.token }}
 
-  generate_rootfs:
-    runs-on: tt-beta-ubuntu-2204-xlarge
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Install dependencies
+    - name: Upload packages to release
       run: |
-        sudo apt-get update -qq && sudo apt-get install -qq qemu-user-static qemu-utils debootstrap
-
-    - name: Build disk image 
-      run: |
-        sudo ./build-image.sh 
-
-    - name: Archive artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: tt-bh-disk-image
-        path: |
-          debian-riscv64.img
+        gh release upload ${{ github.ref_name }} Image fw_jump.bin blackhole-p100.dtb \
+          tt-bh-linux.zip tt-bh-disk-image.zip
+      env:
+        GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This always generates release-notes.md with every build, to make it easier to test changes (they aren't published for anything but tagged builds).

Output from a test run can be seen here:

https://github.com/olofj/tt-bh-linux/releases/tag/v0.2.1-test4