### PR TITLE
Improve harvested L2CPU/DRAM messaging to user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ endif
 # if you have one
 DISK_IMAGE := rootfs.ext4
 
+L2CPU := 0
+
 # Use bash as the shell
 SHELL := /bin/bash
 
@@ -73,10 +75,10 @@ help:
 #################################
 # Recipes that run things
 
-# Boot the Blackhole RISC-V CPU
+# Boot one L2CPU in Blackhole RISC-V CPU
 boot: _need_linux _need_opensbi _need_dtb _need_rootfs _need_hosttool _need_python _need_luwen _need_ttkmd
-	$(PYTHON) boot.py --boot --opensbi_bin fw_jump.bin --opensbi_dst 0x400030000000 --rootfs_bin $(DISK_IMAGE) --rootfs_dst 0x4000e5000000 --kernel_bin Image --kernel_dst 0x400030200000 --dtb_bin blackhole-p100.dtb --dtb_dst 0x400030100000
-	./console/tt-bh-linux
+	$(PYTHON) boot.py --boot --l2cpu $(L2CPU) --opensbi_bin fw_jump.bin --opensbi_dst 0x400030000000 --rootfs_bin $(DISK_IMAGE) --rootfs_dst 0x4000e5000000 --kernel_bin Image --kernel_dst 0x400030200000 --dtb_bin blackhole-p100.dtb --dtb_dst 0x400030100000
+	./console/tt-bh-linux --l2cpu $(L2CPU)
 
 # Connect to console (requires a booted RISC-V)
 connect: _need_hosttool _need_ttkmd

--- a/boot.py
+++ b/boot.py
@@ -87,8 +87,8 @@ def main():
     enabled_l2cpu = telemetry.enabled_l2cpu
     enabled_gddr = telemetry.enabled_gddr
     for l2cpu in l2cpus_to_boot:
-        assert (enabled_l2cpu >> l2cpu) & 1, "L2CPU {} is harvested".format(l2cpu)
-        assert (enabled_gddr >> l2cpu_gddr_enable_bit_mapping[l2cpu]) & 1, "DRAM attached to L2CPU {} is harvested".format(l2cpu)
+        assert (enabled_l2cpu >> l2cpu) & 1, "L2CPU {} is harvested, try booting L2CPU {} with make L2CPU={} boot".format(l2cpu, l2cpu ^ 0b1, l2cpu ^ 0b1)
+        assert (enabled_gddr >> l2cpu_gddr_enable_bit_mapping[l2cpu]) & 1, "DRAM attached to L2CPU {} is harvested, try booting L2CPU {} with make L2CPU={} boot".format(l2cpu, l2cpu ^ 0b1, l2cpu ^0b1)
     for idx, l2cpu in enumerate(l2cpus_to_boot):
         (l2cpu_noc_x, l2cpu_noc_y) = l2cpu_tile_mapping[l2cpu]
         l2cpu_base = 0xfffff7fefff10000


### PR DESCRIPTION
1. Add a makefile arg that lets the user specify which L2CPU to boot.
Note: This is not intended for booting multiple L2CPUs at once. We will come up with a separate target for that

2. Add more text to the error message that gets printed when L2CPU/DRAM is harvested, nudging the user to try booting another L2CPU like `make L2CPU=1 boot`