### PR TITLE
l2cpu: add ptr to entire memory region using 2 4G TLB Windows

### DIFF
--- a/console/l2cpu.h
+++ b/console/l2cpu.h
@@ -17,6 +17,11 @@ class L2CPU
     int idx;
     uint64_t starting_address, memory_size;
 
+    // ptrs to first (0x4000'0000'0000) and second (0x4001'0000'0000) memory regions of L2CPU memory
+    std::unique_ptr<TlbWindow4G> first, second;
+    // ptr to 8G region that has the above 2 regions stacked together
+    uint8_t *memory;
+
     xy_t coordinates;
 
 public:
@@ -24,6 +29,8 @@ public:
 
     uint64_t get_starting_address();
     uint64_t get_memory_size();
+
+    uint8_t* get_memory_ptr();
 
     xy_t get_coordinates();
 

--- a/console/test.cpp
+++ b/console/test.cpp
@@ -40,8 +40,23 @@ void TestL2CPUNocNodeID(){
     }
 }
 
+void TestMemoryPtr(){
+    for (int i=0; i<4; i++){
+        L2CPU l2cpu(i);
+        std::uniform_int_distribution<uint64_t> distribution(0, l2cpu.get_memory_size());
+        uint64_t starting_address = l2cpu.get_starting_address();
+        uint8_t *memory = l2cpu.get_memory_ptr();
+        for (int i=0; i< 100; i++){
+            uint64_t random_address = distribution(gen);
+            random_address -= (random_address % 4); // Align address to 4 bytes
+            assert(l2cpu.read32(starting_address + random_address) == *(reinterpret_cast<uint32_t*>(memory + random_address)));
+        }
+    }
+}
+
 int main(){
     TestL2CPU23SharedMemoryTile();
     TestL2CPUNocNodeID();
+    TestMemoryPtr();
     return 0;
 }

--- a/console/tlb.cpp
+++ b/console/tlb.cpp
@@ -3,7 +3,6 @@
 
 #include <sys/mman.h>
 #include <sys/ioctl.h>
-#include <cassert>
 #include "tlb.h"
 
 TlbHandle::TlbHandle(int fd, size_t size, const tenstorrent_noc_tlb_config &config)
@@ -52,37 +51,5 @@ TlbHandle::~TlbHandle() noexcept
 
     munmap(tlb_base, tlb_size);
     ioctl(fd, TENSTORRENT_IOCTL_FREE_TLB, &free_tlb);
-}
-
-
-TlbWindow2M::TlbWindow2M(int fd, uint16_t x, uint16_t y, uint64_t addr)
-: offset(addr & WINDOW_MASK)
-{
-    tenstorrent_noc_tlb_config config{
-        .addr = addr & ~WINDOW_MASK,
-        .x_end = x,
-        .y_end = y,
-    };
-
-    window = std::make_unique<TlbHandle>(fd, WINDOW_SIZE, config);
-}
-
-
-void TlbWindow2M::write32(uint64_t addr, uint32_t value){
-    assert(offset + addr + 4 <= WINDOW_SIZE);
-    assert(((offset + addr) % 4) == 0);
-    void *ptr = window->data() + offset + addr;
-    *reinterpret_cast<volatile uint32_t *>(ptr) = value;
-}
-
-uint32_t TlbWindow2M::read32(uint64_t addr){
-    assert(offset + addr + 4 <= WINDOW_SIZE);
-    assert(((offset + addr) % 4) == 0);
-    void *ptr = window->data() + offset + addr;
-    return *reinterpret_cast<volatile uint32_t *>(ptr);
-}
-
-uint8_t* TlbWindow2M::get_window(){
-    return window.get()->data() + offset;
 }
 

--- a/console/tlb.cpp
+++ b/console/tlb.cpp
@@ -5,7 +5,7 @@
 #include <sys/ioctl.h>
 #include "tlb.h"
 
-TlbHandle::TlbHandle(int fd, size_t size, const tenstorrent_noc_tlb_config &config)
+TlbHandle::TlbHandle(int fd, size_t size, const tenstorrent_noc_tlb_config &config, void* base)
     : fd(fd)
     , tlb_size(size)
 {
@@ -29,7 +29,7 @@ TlbHandle::TlbHandle(int fd, size_t size, const tenstorrent_noc_tlb_config &conf
         exit(1);
     }
 
-    void *mem = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, allocate_tlb.out.mmap_offset_uc);
+    void *mem = mmap(base, size, PROT_READ | PROT_WRITE, base==nullptr? MAP_SHARED: MAP_SHARED | MAP_FIXED, fd, allocate_tlb.out.mmap_offset_uc);
     if (mem == MAP_FAILED) {
         tenstorrent_free_tlb free_tlb{};
         free_tlb.in.id = tlb_id;

--- a/console/tlb.h
+++ b/console/tlb.h
@@ -28,7 +28,7 @@ class TlbHandle
     size_t tlb_size;
 
 public:
-    TlbHandle(int fd, size_t size, const tenstorrent_noc_tlb_config &config);
+    TlbHandle(int fd, size_t size, const tenstorrent_noc_tlb_config &config, void* base=nullptr);
 
     uint8_t* data();
     size_t size() const;
@@ -47,7 +47,7 @@ class TlbWindow
     std::unique_ptr<TlbHandle> window;
 
 public:
-    TlbWindow(int fd, uint16_t x, uint16_t y, uint64_t addr);
+    TlbWindow(int fd, uint16_t x, uint16_t y, uint64_t addr, void* base=nullptr);
 
     void write32(uint64_t addr, uint32_t value);
 
@@ -57,7 +57,7 @@ public:
 };
 
 template <size_t WINDOW_SIZE>
-TlbWindow<WINDOW_SIZE>::TlbWindow(int fd, uint16_t x, uint16_t y, uint64_t addr)
+TlbWindow<WINDOW_SIZE>::TlbWindow(int fd, uint16_t x, uint16_t y, uint64_t addr, void* base)
 : offset(addr & WINDOW_MASK)
 {
     tenstorrent_noc_tlb_config config{
@@ -66,7 +66,7 @@ TlbWindow<WINDOW_SIZE>::TlbWindow(int fd, uint16_t x, uint16_t y, uint64_t addr)
         .y_end = y,
     };
 
-    window = std::make_unique<TlbHandle>(fd, WINDOW_SIZE, config);
+    window = std::make_unique<TlbHandle>(fd, WINDOW_SIZE, config, base);
 }
 
 

--- a/console/tlb.h
+++ b/console/tlb.h
@@ -6,8 +6,12 @@
 #include <unistd.h>
 #include <iostream>
 #include <memory>
+#include <cassert>
 
 #include "ioctl.h"
+
+static constexpr size_t TWO_MEG = 1 << 21;
+static constexpr size_t FOUR_GIG = 1ULL << 32;
 
 struct xy_t
 {
@@ -33,9 +37,9 @@ public:
 
 };
 
-class TlbWindow2M
+template <size_t WINDOW_SIZE>
+class TlbWindow
 {
-    static constexpr size_t WINDOW_SIZE = 1 << 21;
     static constexpr size_t WINDOW_MASK = WINDOW_SIZE - 1;
     static_assert((WINDOW_SIZE & WINDOW_MASK) == 0, "WINDOW_SIZE must be a power of 2");
 
@@ -43,7 +47,7 @@ class TlbWindow2M
     std::unique_ptr<TlbHandle> window;
 
 public:
-    TlbWindow2M(int fd, uint16_t x, uint16_t y, uint64_t addr);
+    TlbWindow(int fd, uint16_t x, uint16_t y, uint64_t addr);
 
     void write32(uint64_t addr, uint32_t value);
 
@@ -51,4 +55,42 @@ public:
 
     uint8_t* get_window();
 };
+
+template <size_t WINDOW_SIZE>
+TlbWindow<WINDOW_SIZE>::TlbWindow(int fd, uint16_t x, uint16_t y, uint64_t addr)
+: offset(addr & WINDOW_MASK)
+{
+    tenstorrent_noc_tlb_config config{
+        .addr = addr & ~WINDOW_MASK,
+        .x_end = x,
+        .y_end = y,
+    };
+
+    window = std::make_unique<TlbHandle>(fd, WINDOW_SIZE, config);
+}
+
+
+template <size_t WINDOW_SIZE>
+void TlbWindow<WINDOW_SIZE>::write32(uint64_t addr, uint32_t value){
+    assert(offset + addr + 4 <= WINDOW_SIZE);
+    assert(((offset + addr) % 4) == 0);
+    void *ptr = window->data() + offset + addr;
+    *reinterpret_cast<volatile uint32_t *>(ptr) = value;
+}
+
+template <size_t WINDOW_SIZE>
+uint32_t TlbWindow<WINDOW_SIZE>::read32(uint64_t addr){
+    assert(offset + addr + 4 <= WINDOW_SIZE);
+    assert(((offset + addr) % 4) == 0);
+    void *ptr = window->data() + offset + addr;
+    return *reinterpret_cast<volatile uint32_t *>(ptr);
+}
+
+template <size_t WINDOW_SIZE>
+uint8_t* TlbWindow<WINDOW_SIZE>::get_window(){
+    return window.get()->data() + offset;
+}
+
+using TlbWindow2M = TlbWindow<TWO_MEG>;
+using TlbWindow4G = TlbWindow<FOUR_GIG>;
 #endif


### PR DESCRIPTION
virtio drivers require device side to be able to do "DMA" to any memory address, so we add a `get_memory_ptr()` method to L2CPU. 

This uses the 2 TlbWindow4G windows that are aligned/stacked one after the other and point to 0x4000'0000'0000 and 0x4001'0000'0000