### PR TITLE
Add virtio device implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,36 @@ jobs:
         name: tt-bh-disk-image-zip
         path: tt-bh-disk-image.zip
 
+  test:
+    runs-on: tt-beta-ubuntu-2204-p150b-large-stable
+    needs: [build, generate_rootfs]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -qq unzip expect
+      - name: Download tt-bh-linux artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tt-bh-linux
+
+      - name: Download zipped Linux artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tt-bh-linux-zip
+
+      - name: Dependencies
+        run: |
+          ls
+          make install_all
+          TT_INSTALL_KMD=false make install_tt_installer
+      
+      - name: Boot
+        run: |
+          for i in {0..499}; do expect watch.expect || true; sleep 10s; pkill tt-bh-linux || true; done
+
+  
   upload_release_artifacts:
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'release'
     needs: [build, generate_rootfs]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,7 +151,7 @@ jobs:
       
       - name: Boot
         run: |
-          for i in {0..499}; do expect watch.expect || true; sleep 10s; pkill tt-bh-linux || true; done
+          for i in {0..499}; do expect watch.expect || true; pkill tt-bh-linux || true; done
 
   
   upload_release_artifacts:

--- a/Makefile
+++ b/Makefile
@@ -296,6 +296,9 @@ download_rootfs: _need_wget _need_unxz
 	unzip tt-bh-disk-image.zip
 	rm tt-bh-disk-image.zip
 	mv debian-riscv64.img rootfs.ext4
+	qemu-img resize rootfs.ext4 10G
+	e2fsck -f rootfs.ext4
+	resize2fs rootfs.ext4
 
 # Download prebuilt Linux, opensbi and dtb
 download_prebuilt: _need_wget _need_unzip

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,8 @@ boot: _need_linux _need_opensbi _need_dtb _need_rootfs _need_hosttool _need_pyth
 	$(PYTHON) boot.py --boot --l2cpu $(L2CPU) --opensbi_bin fw_jump.bin --opensbi_dst 0x400030000000 --rootfs_dst 0x4000e5000000 --kernel_bin Image --kernel_dst 0x400030200000 --dtb_bin blackhole-p100.dtb --dtb_dst 0x400030100000
 	./console/tt-bh-linux --l2cpu $(L2CPU)
 
-boot_all: _need_linux _need_opensbi _need_dtb _need_dtb_all _need_rootfs _need_hosttool _need_python _need_luwen _need_ttkmd
-	$(PYTHON) boot.py --boot --l2cpu 0 1 2 3 --opensbi_bin fw_jump.bin --opensbi_dst 0x400030000000 0x400030000000 0x400030000000 0x4000b0000000 --rootfs_bin $(DISK_IMAGE) --rootfs_dst 0x4000e5000000 0x4000e5000000 0x400065000000 0x4000e5000000  --kernel_bin Image --kernel_dst 0x400030200000 0x400030200000 0x400030200000 0x4000b0200000 --dtb_bin blackhole-p100.dtb blackhole-p100.dtb blackhole-p100-2.dtb blackhole-p100-3.dtb --dtb_dst 0x400030100000 0x400030100000 0x400030100000 0x4000b0100000
+# boot_all: _need_linux _need_opensbi _need_dtb _need_dtb_all _need_rootfs _need_hosttool _need_python _need_luwen _need_ttkmd
+# 	$(PYTHON) boot.py --boot --l2cpu 0 1 2 3 --opensbi_bin fw_jump.bin --opensbi_dst 0x400030000000 0x400030000000 0x400030000000 0x4000b0000000 --rootfs_bin $(DISK_IMAGE) --rootfs_dst 0x4000e5000000 0x4000e5000000 0x400065000000 0x4000e5000000  --kernel_bin Image --kernel_dst 0x400030200000 0x400030200000 0x400030200000 0x4000b0200000 --dtb_bin blackhole-p100.dtb blackhole-p100.dtb blackhole-p100-2.dtb blackhole-p100-3.dtb --dtb_dst 0x400030100000 0x400030100000 0x400030100000 0x4000b0100000
 
 # Connect to console (requires a booted RISC-V)
 connect: _need_hosttool _need_ttkmd
@@ -93,26 +93,26 @@ connect: _need_hosttool _need_ttkmd
 ssh:
 	ssh -F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o NoHostAuthenticationForLocalhost=yes -o User=debian -p2222 localhost
 
-SESSION = connect_all
-# Launch tmux with a 2x2 grid and connect to each l2cpu in each
-connect_all: _need_tmux
-	# Kill any existing sessions named connect_all
-	tmux has-session -t "$(SESSION)" 2>/dev/null && tmux kill-session -t "$(SESSION)" || true
+# SESSION = connect_all
+# # Launch tmux with a 2x2 grid and connect to each l2cpu in each
+# connect_all: _need_tmux
+# 	# Kill any existing sessions named connect_all
+# 	tmux has-session -t "$(SESSION)" 2>/dev/null && tmux kill-session -t "$(SESSION)" || true
 
-	tmux new-session  -d -s "$(SESSION)" './console/tt-bh-linux --l2cpu 0' 	# pane 0
-	tmux split-window -h -t "$(SESSION)":0 './console/tt-bh-linux --l2cpu 1' 	# pane 1 (right)
-	tmux select-pane   -t "$(SESSION)":0.0 									# back to pane 0
-	tmux split-window -v -t "$(SESSION)":0 './console/tt-bh-linux --l2cpu 2' 	# pane 2 (bottom-left)
-	tmux select-pane   -t "$(SESSION)":0.1 									# go to pane 1
-	tmux split-window -v -t "$(SESSION)":0 './console/tt-bh-linux --l2cpu 3' 	# pane 3 (bottom-right)
-	tmux select-layout -t "$(SESSION)":0 tiled 								# ensure 2x2 grid
+# 	tmux new-session  -d -s "$(SESSION)" './console/tt-bh-linux --l2cpu 0' 	# pane 0
+# 	tmux split-window -h -t "$(SESSION)":0 './console/tt-bh-linux --l2cpu 1' 	# pane 1 (right)
+# 	tmux select-pane   -t "$(SESSION)":0.0 									# back to pane 0
+# 	tmux split-window -v -t "$(SESSION)":0 './console/tt-bh-linux --l2cpu 2' 	# pane 2 (bottom-left)
+# 	tmux select-pane   -t "$(SESSION)":0.1 									# go to pane 1
+# 	tmux split-window -v -t "$(SESSION)":0 './console/tt-bh-linux --l2cpu 3' 	# pane 3 (bottom-right)
+# 	tmux select-layout -t "$(SESSION)":0 tiled 								# ensure 2x2 grid
 
-	# If we're already inside a tmux session, we need to use switch-client
-	if [ -n "$$TMUX" ]; then \
-        tmux switch-client -t "$(SESSION)"; \
-    else \
-        tmux attach-session -t "$(SESSION)"; \
-    fi
+# 	# If we're already inside a tmux session, we need to use switch-client
+# 	if [ -n "$$TMUX" ]; then \
+#         tmux switch-client -t "$(SESSION)"; \
+#     else \
+#         tmux attach-session -t "$(SESSION)"; \
+#     fi
 
 user-data.img: user-data.yaml _need_cloud_image_utils
 	cloud-localds -d raw user-data.img  user-data.yaml

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ help:
 
 # Boot one L2CPU in Blackhole RISC-V CPU
 boot: _need_linux _need_opensbi _need_dtb _need_rootfs _need_hosttool _need_python _need_luwen _need_ttkmd
-	$(PYTHON) boot.py --boot --l2cpu $(L2CPU) --opensbi_bin fw_jump.bin --opensbi_dst 0x400030000000 --rootfs_bin $(DISK_IMAGE) --rootfs_dst 0x4000e5000000 --kernel_bin Image --kernel_dst 0x400030200000 --dtb_bin blackhole-p100.dtb --dtb_dst 0x400030100000
+	$(PYTHON) boot.py --boot --l2cpu $(L2CPU) --opensbi_bin fw_jump.bin --opensbi_dst 0x400030000000 --rootfs_dst 0x4000e5000000 --kernel_bin Image --kernel_dst 0x400030200000 --dtb_bin blackhole-p100.dtb --dtb_dst 0x400030100000
 	./console/tt-bh-linux --l2cpu $(L2CPU)
 
 boot_all: _need_linux _need_opensbi _need_dtb _need_dtb_all _need_rootfs _need_hosttool _need_python _need_luwen _need_ttkmd

--- a/boot.py
+++ b/boot.py
@@ -29,7 +29,7 @@ def parse_args():
     parser.add_argument("--l2cpu", type=int, nargs="+", default=[0], help="list of L2CPUs to boot")
 
     # If using FW_PAYLOAD, set these args for rootfs and opensbi
-    parser.add_argument("--rootfs_bin", type=str, required=True, help="Path to rootfs bin file")
+    parser.add_argument("--rootfs_bin", type=str, required=False, help="Path to rootfs bin file")
     parser.add_argument("--rootfs_dst", type=str, nargs="+", required=True, help="list of Destination address for rootfs for each l2cpu")
     parser.add_argument("--opensbi_bin", type=str, required=True, help="Path to opensbi bin file")
     parser.add_argument("--opensbi_dst", type=str, nargs="+", required=True, help="list of Destination address for opensbi for each l2cpu")
@@ -95,9 +95,11 @@ def main():
         l2cpu_base = 0xfffff7fefff10000
 
         opensbi_addr = int(args.opensbi_dst[idx], 16)
-        rootfs_addr = int(args.rootfs_dst[idx], 16)
         opensbi_bytes = read_bin_file(args.opensbi_bin)
-        rootfs_bytes = read_bin_file(args.rootfs_bin)
+
+        if args.rootfs_dst and args.rootfs_bin:
+            rootfs_addr = int(args.rootfs_dst[idx], 16)
+            rootfs_bytes = read_bin_file(args.rootfs_bin)
             
         if args.kernel_dst and args.kernel_bin:
             kernel_addr = int(args.kernel_dst[idx], 16)
@@ -115,8 +117,10 @@ def main():
 
         print(f"Writing OpenSBI to 0x{opensbi_addr:x}")
         chip.noc_write(0, l2cpu_noc_x, l2cpu_noc_y, opensbi_addr, opensbi_bytes)
-        print(f"Writing rootfs to 0x{rootfs_addr:x}")
-        chip.noc_write(0, l2cpu_noc_x, l2cpu_noc_y, rootfs_addr, rootfs_bytes)
+
+        if args.rootfs_dst and args.rootfs_bin:
+            print(f"Writing rootfs to 0x{rootfs_addr:x}")
+            chip.noc_write(0, l2cpu_noc_x, l2cpu_noc_y, rootfs_addr, rootfs_bytes)
 
         if args.kernel_dst and args.kernel_bin:
             print(f"Writing Kernel to 0x{kernel_addr:x}")

--- a/boot.py
+++ b/boot.py
@@ -83,7 +83,7 @@ def main():
     chip = PciChip(0)
     pci_board_reset([0])
 
-    time.sleep(1) # Sleep 1s, telemetry sometimes not available immediately after reset
+    time.sleep(5) # Sleep 5s, telemetry sometimes not available immediately after reset
     telemetry = chip.get_telemetry()
     enabled_l2cpu = telemetry.enabled_l2cpu
     enabled_gddr = telemetry.enabled_gddr

--- a/console/Makefile
+++ b/console/Makefile
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
-
-CXXFLAGS := -Wall -O2 -MMD -MP
+CXXFLAGS := -Wall -fpermissive -O2 -MMD -MP -g
 LDLIBS := -lvdeslirp -lslirp
 LINK.o := $(LINK.cc)
 

--- a/console/disk.hpp
+++ b/console/disk.hpp
@@ -1,0 +1,139 @@
+#include <atomic>
+#include <cassert>
+#include <cstdio>
+#include <getopt.h>
+#include <inttypes.h>
+#include <iostream>
+#include <queue>
+#include <signal.h>
+#include <stdint.h>
+#include <string.h>
+#include <string> // Added for std::string
+#include <sys/select.h>
+#include <sys/time.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <mutex> // Added for std::mutex
+extern "C" {
+#define class __class_compat // Rename 'class' to avoid C++ keyword conflict
+
+#include <linux/virtio_blk.h>
+#include <linux/virtio_ring.h>
+#include <linux/virtio_mmio.h>
+#include <linux/virtio_config.h>
+#include <linux/virtio_ids.h>
+
+#ifdef class
+#undef class // Undefine our temporary macro if it was defined
+#endif
+}
+
+#include "l2cpu.h"
+#include "virtiodevice.hpp"
+
+class VirtioBlk : public VirtioDevice {
+public:
+    int sector_size = 512;
+    int fd = -1;
+    uint8_t* mapped_data = nullptr;
+    size_t file_size = 0;
+    size_t num_sectors = 0;
+    struct virtio_blk_outhdr *req;
+    std::string disk_image_path;
+
+    VirtioBlk(int l2cpu_idx, std::atomic<bool>& exit_flag, std::mutex& interrupt_register_lock, const std::string& image_path)
+        : VirtioDevice(l2cpu_idx, exit_flag, interrupt_register_lock, 33, (2ULL * 1024 * 1024)), disk_image_path(image_path) {
+        // FIXME: I don't know if we're handling the last sector's size, reads and writes properly
+        
+        num_queues = 1;
+        device_features_list[0] = 0;
+        device_features_list[1] = 1<<(VIRTIO_F_VERSION_1-32);
+        
+        fd = open(disk_image_path.c_str(), O_RDWR);
+        if (fd == -1) {
+            perror(("Failed to open file: " + disk_image_path).c_str());
+            return;
+        }
+        struct stat sb;
+        if (fstat(fd, &sb) == -1) {
+            perror("Failed to get file size");
+            close(fd);
+            fd = -1;
+            return;
+        }
+        file_size = sb.st_size;
+        num_sectors = (file_size + sector_size - 1) / sector_size;
+        mapped_data = (uint8_t*)mmap(NULL, file_size, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
+        if (mapped_data == MAP_FAILED) {
+            perror("Failed to mmap file");
+            close(fd);
+            fd = -1;
+            return;
+        }
+        *device_id = VIRTIO_ID_BLOCK;
+
+        struct virtio_blk_config *device_config = reinterpret_cast<struct virtio_blk_config*>(mmio_base + VIRTIO_MMIO_CONFIG);
+        device_config->capacity = num_sectors;
+
+        queue_header_size = sizeof(struct virtio_blk_outhdr);
+    }
+
+    void process_queue_start(int queue_idx, uint8_t* addr, uint64_t len) override {
+        assert(queue_idx==0);
+        req = (struct virtio_blk_outhdr*)addr;
+    }
+
+    void process_queue_data(int queue_idx, uint8_t* addr, uint64_t len) override {
+        /*
+        FIXME: x280 side driver seems to use some kind of in memory cache 
+        and coalesces writes. write speeds are abnormally high when cache is used and
+        then plummet when a bunch of coalesced writes are dumped to this program to
+        handle (which it can't handle fast enough)
+
+        A consequence of this is that a userspace program running on X280 thinks that a 
+        write may have happened even though the request for the write was not yet processed
+        by this program on host
+
+        If you try running this
+        dd if=/dev/random of=1.img count=1024 bs=1M status=progress
+
+        you'll see that the number of bytes written "increases" for a bit and then "stops"
+        for a while, then resumes increasing again
+
+        the driver sends a bunch of write requests over the queue to this program only
+        when the dd command is in it's "stopped" stage.
+
+        This results in weird behaviour like being unable to interrupt the dd command
+        (or any other command doing writes) till those writes are processed by this program
+
+        Similarly, wget's from host to x280 may show abnormal speeds while the cache is in use
+        */
+
+        // Only one queue, so queue_idx is always 0
+        assert(queue_idx==0);
+
+        // Use req->type to determine read/write
+        switch (req->type) {
+            case VIRTIO_BLK_T_IN:
+                memcpy(addr, mapped_data + ((sector_size * req->sector)), len);
+                break;
+            case VIRTIO_BLK_T_OUT:
+                memcpy(mapped_data + ((sector_size * req->sector)), addr, len);
+                break;
+            default:
+                printf("Unimplemented Request Type: %d Len: %lu\n", req->type, len);
+        }
+    }
+
+    void process_queue_complete(int queue_idx, uint8_t* addr, uint64_t len) override {
+        assert(queue_idx==0);
+        // For block device, set status byte to 0 (success)
+        *addr = 0;
+    }
+
+    inline bool queue_has_data(int queue_idx){
+        return true;
+    }
+
+};

--- a/console/disk.hpp
+++ b/console/disk.hpp
@@ -42,8 +42,8 @@ public:
     struct virtio_blk_outhdr *req;
     std::string disk_image_path;
 
-    VirtioBlk(int l2cpu_idx, std::atomic<bool>& exit_flag, std::mutex& interrupt_register_lock, const std::string& image_path)
-        : VirtioDevice(l2cpu_idx, exit_flag, interrupt_register_lock, 33, (2ULL * 1024 * 1024)), disk_image_path(image_path) {
+    VirtioBlk(int l2cpu_idx, std::atomic<bool>& exit_flag, std::mutex& interrupt_register_lock, int interrupt_number_, uint64_t mmio_region_offset_, const std::string& image_path)
+        : VirtioDevice(l2cpu_idx, exit_flag, interrupt_register_lock, interrupt_number_, mmio_region_offset_), disk_image_path(image_path) {
         // FIXME: I don't know if we're handling the last sector's size, reads and writes properly
         
         num_queues = 1;

--- a/console/network.hpp
+++ b/console/network.hpp
@@ -9,157 +9,117 @@
 #include <sys/time.h>
 #include <sys/select.h>
 #include <signal.h>
+#include <atomic>
+#include <cassert>
+#include <cstdio>
+#include <getopt.h>
 #include <inttypes.h>
 #include <iostream>
-#include <cassert>
-#include <getopt.h>
-#include <atomic>
+#include <queue>
+#include <signal.h>
+#include <slirp/libslirp.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/time.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <mutex> // Added for std::mutex
+extern "C" {
+#define class __class_compat // Rename 'class' to avoid C++ keyword conflict
+
+#include <linux/virtio_net.h>
+#include <linux/virtio_ring.h>
+
+#ifdef class
+#undef class // Undefine our temporary macro if it was defined
+#endif
+}
 
 #include "l2cpu.h"
+#include "virtiodevice.hpp"
 
 extern "C" {
 #include <slirp/libvdeslirp.h>
 }
 
-#define MTU 1500 // MTU (Ignoring ethernet header) that is set for adapter = 1500
-#define PACKET_SIZE 1514 // MTU + ethernet header size = 1514
+#define PACKET_SIZE 1514
 
-#define PMEM_REGION_SIZE (1200ULL*1024*1024)
-#define TTETH_SHM_REGION_OFFSET (PMEM_REGION_SIZE + (2ULL*1024*1024))
-
-#define X280_REGISTERS 0xFFFFF7FEFFF10000ULL
-#define INTERRUPT_NUMBER 33
-
-#define NETWORK_BUFFER_SIZE 500
-
-#define TTETH_MAGIC 0x4D13ED8246A0f856ULL
-
-struct packet{
-    uint32_t len;
-    char data[PACKET_SIZE];
-};
-
-struct one_side_buffer{
-    uint32_t location_sent;
-    uint32_t location_rcvd;
-    struct packet buffer[NETWORK_BUFFER_SIZE];
-};
-
-struct shared_data{
-    uint64_t magic;
-    uint32_t interrupts;
-    struct one_side_buffer send;
-    struct one_side_buffer recv;
-};
-
-
-int network_loop(int l2cpu_idx, std::atomic<bool>& exit_thread_flag){
-
-    L2CPU l2cpu(l2cpu_idx);
-
-    // Assumes that 2M memory region is at the region just before the beginning of th pmem, which itself is at the end of the dram
-    uint64_t address = l2cpu.get_starting_address() + l2cpu.get_memory_size() - TTETH_SHM_REGION_OFFSET;
-
-    auto window = l2cpu.get_persistent_2M_tlb_window(address);
-    struct shared_data* base = reinterpret_cast<struct shared_data*>(window->get_window());
-
-    uint64_t interrupt_address = X280_REGISTERS + 0x404; // X280 Global Interrupts Register Bits 31 to 0
-    // For some reason, interrupts 6->9 don't work for this even though I think they should
-    // Only interrupts 0->5 are reserved, don't know if 6->9 are also connected to something else
-    // Interrupts are triggered by setting bit INTERRUPT_NUMBER-5 in the register referenced above
-    assert(INTERRUPT_NUMBER >= 10 && INTERRUPT_NUMBER <= 36);
-    auto interrupt_address_window = l2cpu.get_persistent_2M_tlb_window(interrupt_address);
-    uint32_t* interrupt_register = reinterpret_cast<uint32_t*>(interrupt_address_window->get_window());
-
-    memset(&(base->send), 0, sizeof(struct one_side_buffer));
-    memset(&(base->recv), 0, sizeof(struct one_side_buffer));
-    struct one_side_buffer* send = &(base->send);
-    struct one_side_buffer* recv = &(base->recv);
-
+class VirtioNet : public VirtioDevice {
+public:
     SlirpConfig slirpcfg;
-    slirpcfg.if_mru = PACKET_SIZE;
-    slirpcfg.if_mtu = PACKET_SIZE;
-    struct vdeslirp *myslirp;
-    vdeslirp_init(&slirpcfg, VDE_INIT_DEFAULT);
-    myslirp = vdeslirp_open(&slirpcfg);
+    struct vdeslirp *myslirp = nullptr;
+    int slirp_fd = -1;
+    uint8_t buffer[PACKET_SIZE];
 
-    // Port Forwarding for SSH
-    struct in_addr host, guest;
-    inet_aton("127.0.0.1", &host);
-    inet_aton("10.0.2.15", &guest);
-    vdeslirp_add_fwd(myslirp, 0, host, 2222+l2cpu_idx, guest, 22);
+    VirtioNet(int l2cpu_idx, std::atomic<bool>& exit_flag, std::mutex& interrupt_register_lock)
+        : VirtioDevice(l2cpu_idx, exit_flag, interrupt_register_lock, 32, ((4ULL * 1024 * 1024))) {
 
-    int len, ret_code;
-    int slirp_fd = vdeslirp_fd(myslirp);
-    void *buf=malloc(PACKET_SIZE);
-    struct packet *location;
+        num_queues = 2;
+        device_features_list[0] = 1<<VIRTIO_NET_F_GUEST_CSUM;
+        device_features_list[1] = 1<<(VIRTIO_F_VERSION_1-32);
+        
+        // Slirp setup
+        vdeslirp_init(&slirpcfg, VDE_INIT_DEFAULT);
+        myslirp = vdeslirp_open(&slirpcfg);
+        struct in_addr host, guest;
+        inet_aton("127.0.0.1", &host);
+        inet_aton("10.0.2.15", &guest);
+        vdeslirp_add_fwd(myslirp, 0, host, 2222, guest, 22);
+        slirp_fd = vdeslirp_fd(myslirp);
+        signal(SIGPIPE, SIG_IGN);
 
-    // Prevent writing into a closed socket (which may happen after a TCP reset) 
-    // (which causes a SIGPIPE) from killing the process
-    signal(SIGPIPE, SIG_IGN);
-    // Unused variable, might use it for something in the future so leaving it around
-    // bool irq_asserted = false;
+        *device_id = VIRTIO_ID_NET;
+        queue_header_size = sizeof(struct virtio_net_hdr_mrg_rxbuf);
+      }
 
-    while (!exit_thread_flag){
-        if (base->magic != TTETH_MAGIC) {
-            printf("Magic was %" PRIu64 ", not %lld trying again\n", base->magic, TTETH_MAGIC);
-            break;
+    void process_queue_start(int queue_idx, uint8_t* addr, uint64_t len) override {
+        // Do nothing here
+    }
+
+    void process_queue_data(int queue_idx, uint8_t* addr, uint64_t len) override {
+        // Do nothing here
+    }
+
+    void process_queue_complete(int queue_idx, uint8_t* addr, uint64_t len) override {
+      /*
+      For the network device, we seem to always just get one descriptor of size 1514+sizeof(struct virtio_net_hdr_mrg_rxbuf)
+      So we process that in this function cause the last descriptor doesn't have the next flag set
+      */
+      if (queue_idx==0){
+          struct virtio_net_hdr_mrg_rxbuf* hdr = reinterpret_cast<struct virtio_net_hdr_mrg_rxbuf*>(addr);
+          hdr->hdr.flags = 0;
+          hdr->num_buffers = 1;
+          hdr->hdr.gso_type = 0;
+          hdr->hdr.gso_size = 0;
+          ssize_t pktlen = vdeslirp_recv(myslirp, buffer, PACKET_SIZE);
+          if (pktlen > 0) {
+              memcpy(addr + sizeof(struct virtio_net_hdr_mrg_rxbuf), buffer, pktlen);
+          }
+        } else if(queue_idx==1) {
+            uint64_t payload_len = len - sizeof(struct virtio_net_hdr_mrg_rxbuf);
+            memcpy(buffer, addr + sizeof(struct virtio_net_hdr_mrg_rxbuf), payload_len);
+            int ret = vdeslirp_send(myslirp, buffer, payload_len);
+            if (ret < 0) {
+                printf("vdeslirp_send failed: %d\n", ret);
+            }
         }
+    }
+
+    inline bool queue_has_data(int queue_idx){
+      if(queue_idx==0){
+        // Check if slirp has data for us, if so return true
         struct timeval tv;
         fd_set rfds;
         FD_ZERO(&rfds);
         FD_SET(slirp_fd, &rfds);
         tv.tv_sec = 0;
-        tv.tv_usec = 1;
+        tv.tv_usec = 0;
+        return select(slirp_fd + 1, &rfds, NULL, NULL, &tv) > 0;
 
-        if (base->interrupts == 1){
-            *interrupt_register = (*interrupt_register) & ~(1 << (INTERRUPT_NUMBER - 5));
-            // irq_asserted = false;
-            base->interrupts=0;
-        }
-        ret_code = select(slirp_fd + 1, &rfds, NULL, NULL, &tv);
-        if ((send->location_rcvd != ((send->location_sent + 1)%NETWORK_BUFFER_SIZE)) && ret_code > 0){
-            len = vdeslirp_recv(myslirp, buf, PACKET_SIZE);
-
-            uint32_t location_sent = send->location_sent;
-
-            location = send->buffer + location_sent;
-            memcpy(location->data, buf, len);
-            location->len = len;
-
-            // Memory barrier to ensure data is written before updating the pointer
-            __sync_synchronize();
-
-            send->location_sent = (location_sent + 1) % NETWORK_BUFFER_SIZE; // pointer to data
-            // Set the (Interrupt_number -5)th bit in the X280_Global_Interrupts_31_0 register to trigger an interrupt
-            // Something about first 6 interrupts being reserved for other uses
-            if(base->interrupts==0){
-                *interrupt_register = (1 << (INTERRUPT_NUMBER - 5));
-                // irq_asserted = true;
-            }
-        }
-        if (recv->location_rcvd!=recv->location_sent){
-            uint32_t location_rcvd = recv->location_rcvd;
-
-            location = recv->buffer + location_rcvd;
-            len = location->len;
-            memcpy(buf, location->data, len);
-
-            // Memory barrier to ensure data is read before updating the pointer
-            __sync_synchronize();
-
-            recv->location_rcvd = (location_rcvd + 1)%NETWORK_BUFFER_SIZE;
-
-            ret_code = vdeslirp_send(myslirp, buf, len);
-            if (ret_code < 0){
-                perror("vdeslirp_send failed");
-                break;
-            }
-        }
+      } else {
+        return true;
+      }
     }
-
-    vdeslirp_close(myslirp);
-    free(buf);
-    return 0;
-}
-
+};

--- a/console/network.hpp
+++ b/console/network.hpp
@@ -53,8 +53,8 @@ public:
     int slirp_fd = -1;
     uint8_t buffer[PACKET_SIZE];
 
-    VirtioNet(int l2cpu_idx, std::atomic<bool>& exit_flag, std::mutex& interrupt_register_lock)
-        : VirtioDevice(l2cpu_idx, exit_flag, interrupt_register_lock, 32, ((4ULL * 1024 * 1024))) {
+    VirtioNet(int l2cpu_idx, std::atomic<bool>& exit_flag, std::mutex& interrupt_register_lock, int interrupt_number_, uint64_t mmio_region_offset_)
+        : VirtioDevice(l2cpu_idx, exit_flag, interrupt_register_lock, interrupt_number_, mmio_region_offset_) {
 
         num_queues = 2;
         device_features_list[0] = 1<<VIRTIO_NET_F_GUEST_CSUM;

--- a/console/virtiodevice.hpp
+++ b/console/virtiodevice.hpp
@@ -327,7 +327,7 @@ public:
                         */
                         uint16_t used_idx = used_q->idx;
                         used_q->ring[used_idx % queue_size].id = desc_idx_first;
-                        used_q->ring[used_idx % queue_size].len = num_bytes_written - queue_header_size;
+                        used_q->ring[used_idx % queue_size].len = num_bytes_written; // Is this the right value? Should it be device dependent
                         __sync_synchronize();
                         used_q->idx = used_idx + 1;
 

--- a/console/virtiodevice.hpp
+++ b/console/virtiodevice.hpp
@@ -1,0 +1,348 @@
+#pragma once
+#include <atomic>
+#include <cstdint>
+#include <cassert>
+#include <cstdio>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <vector>
+#include <mutex> // Added for std::mutex
+#include "l2cpu.h"
+
+/*
+Virtual Base Class that implements most of the device-agnostic functionality needed
+to emulate a the device side of a virtio-mmio device added to the L2CPU's device tree
+*/
+class VirtioDevice {
+protected:
+    int l2cpu_idx;
+    L2CPU l2cpu;
+    // Starting address of L2CPU's DRAM
+    uint64_t starting_address;
+
+    // Ptr to starting address of L2CPU's DRAM
+    // This ptr is used to interact with the virtqueues
+    uint8_t* memory;
+    
+    std::shared_ptr<TlbWindow2M> window, interrupt_address_window; // MMIO window as a class member
+
+    // Ptr to virtio-mmio device's reg region
+    // None of the virtuqeueus/actual data transfer happens here
+    // Only used for config/negotiation
+    uint8_t* mmio_base;
+    uint64_t mmio_region_offset;
+
+    // Interrupt Number specified in device tree for virtio-mmio device
+    int interrupt_number;
+    // Ptr to L2CPU's special interrupt register
+    uint32_t* interrupt_register;
+    // We need to read and write back the interrupt register while setting/clearing interrupts
+    // And since we have multiple threads in parallel doing this, we need a lock for this
+    std::mutex& interrupt_register_lock;
+    
+    std::atomic<bool>& exit_thread_flag;
+
+    // Properties of Virtqueues used by device
+    // Number of virtqueues used by device
+    // Most use 1, some like network may use many
+    // can be overriden by derived class
+    uint32_t num_queues = 1; 
+     // Size of header in descriptor table, 
+     // essentially sort of a "number of bytes to skip" number
+     // can be overriden by derived class
+    uint64_t queue_header_size = 0;
+    // Max size of virtqueue, probably should make this as large as possible, 16384 maybe?
+    uint16_t queue_size = 16384;
+
+    // Pointers to registers within virtio-mmio device's reg region
+    uint32_t *magic_value; // VIRTIO_MMIO_MAGIC_VALUE
+    uint32_t *version; // VIRTIO_MMIO_VERSION
+    uint32_t *device_id; // VIRTIO_MMIO_DEVICE_ID
+    uint32_t *device_features; // VIRTIO_MMIO_DEVICE_FEATURES
+    uint32_t *device_features_sel; // VIRTIO_MMIO_DEVICE_FEATURES_SEL
+    uint32_t *queue_num_max; // VIRTIO_MMIO_QUEUE_NUM_MAX
+    uint32_t *queue_ready; // VIRTIO_MMIO_QUEUE_READY
+    uint32_t *queue_notify; // VIRTIO_MMIO_QUEUE_NOTIFY
+    uint32_t *interrupt_status; // VIRTIO_MMIO_INTERRUPT_STATUS
+    uint32_t *interrupt_ack; // VIRTIO_MMIO_INTERRUPT_ACK
+    uint32_t *status; // VIRTIO_MMIO_STATUS
+    uint32_t *queue_desc_low; // VIRTIO_MMIO_QUEUE_DESC_LOW
+    uint32_t *queue_desc_high; // VIRTIO_MMIO_QUEUE_DESC_HIGH
+    uint32_t *queue_avail_low; // VIRTIO_MMIO_QUEUE_AVAIL_LOW
+    uint32_t *queue_avail_high; // VIRTIO_MMIO_QUEUE_AVAIL_HIGH
+    uint32_t *queue_used_low; // VIRTIO_MMIO_QUEUE_USED_LOW
+    uint32_t *queue_used_high; // VIRTIO_MMIO_QUEUE_USED_HIGH
+    uint32_t *queue_select; // VIRTIO_MMIO_QUEUE_SEL
+
+    uint32_t device_features_list[2] = {0, 0}; // Default, set in subclass constructor or setup
+
+    // Virtqueue addresses that the driver provides the device
+    std::vector<uint64_t> descriptor_table_address;
+    std::vector<uint64_t> available_ring_address;
+    std::vector<uint64_t> used_ring_address;
+    // Pointers to the virtqueues in L2CPU memory
+    std::vector<struct vring_desc*> desc;
+    std::vector<struct vring_avail*> avail;
+    std::vector<struct vring_used*> used;
+
+
+public:
+    VirtioDevice(int l2cpu_idx_, std::atomic<bool>& exit_flag, std::mutex& lock, int interrupt_number_, uint64_t mmio_region_offset_)
+        : l2cpu_idx(l2cpu_idx_), 
+          l2cpu(l2cpu_idx_), 
+          mmio_region_offset(mmio_region_offset_),
+          interrupt_number(interrupt_number_),
+          interrupt_register_lock(lock),
+          exit_thread_flag(exit_flag) {
+
+        starting_address = l2cpu.get_starting_address();
+
+        uint64_t address = starting_address + l2cpu.get_memory_size() - mmio_region_offset;
+        window = l2cpu.get_persistent_2M_tlb_window(address);
+        mmio_base = reinterpret_cast<uint8_t*>(window->get_window());
+
+        memory = l2cpu.get_memory_ptr();
+
+        // TODO: Check if (interrupt_number-5) is in valid 
+        // range, and adjust which register to use accordingly
+        uint64_t interrupt_address = 0xFFFFF7FEFFF10000ULL + 0x404;
+        interrupt_address_window = l2cpu.get_persistent_2M_tlb_window(interrupt_address);
+        interrupt_register = reinterpret_cast<uint32_t*>(interrupt_address_window->get_window());
+
+        // 0->0x100 for generic virtio-mmio config, 0x100 onwards for device specific config
+        // Should probably check if 0x100 is enough for device specific config
+        memset(mmio_base, 0, 0x200);
+        magic_value = reinterpret_cast<uint32_t *>(mmio_base + VIRTIO_MMIO_MAGIC_VALUE);
+        version = reinterpret_cast<uint32_t *>(mmio_base + VIRTIO_MMIO_VERSION);
+        device_id = reinterpret_cast<uint32_t *>(mmio_base + VIRTIO_MMIO_DEVICE_ID);
+        device_features = reinterpret_cast<uint32_t *>(mmio_base + VIRTIO_MMIO_DEVICE_FEATURES);
+        device_features_sel = reinterpret_cast<uint32_t *>(mmio_base + VIRTIO_MMIO_DEVICE_FEATURES_SEL);
+        queue_num_max = reinterpret_cast<uint32_t *>(mmio_base + VIRTIO_MMIO_QUEUE_NUM_MAX);
+        queue_ready = reinterpret_cast<uint32_t *>(mmio_base + VIRTIO_MMIO_QUEUE_READY);
+        queue_notify = reinterpret_cast<uint32_t *>(mmio_base + VIRTIO_MMIO_QUEUE_NOTIFY);
+        interrupt_status = reinterpret_cast<uint32_t *>(mmio_base + VIRTIO_MMIO_INTERRUPT_STATUS);
+        interrupt_ack = reinterpret_cast<uint32_t *>(mmio_base + VIRTIO_MMIO_INTERRUPT_ACK);
+        status = reinterpret_cast<uint32_t *>(mmio_base + VIRTIO_MMIO_STATUS);
+        queue_desc_low = reinterpret_cast<uint32_t *>(mmio_base + VIRTIO_MMIO_QUEUE_DESC_LOW);
+        queue_desc_high = reinterpret_cast<uint32_t *>(mmio_base + VIRTIO_MMIO_QUEUE_DESC_HIGH);
+        queue_avail_low = reinterpret_cast<uint32_t *>(mmio_base + VIRTIO_MMIO_QUEUE_AVAIL_LOW);
+        queue_avail_high = reinterpret_cast<uint32_t *>(mmio_base + VIRTIO_MMIO_QUEUE_AVAIL_HIGH);
+        queue_used_low = reinterpret_cast<uint32_t *>(mmio_base + VIRTIO_MMIO_QUEUE_USED_LOW);
+        queue_used_high = reinterpret_cast<uint32_t *>(mmio_base + VIRTIO_MMIO_QUEUE_USED_HIGH);
+        queue_select = reinterpret_cast<uint32_t *>(mmio_base + VIRTIO_MMIO_QUEUE_SEL);
+
+        *magic_value = ('v' | 'i' << 8 | 'r' << 16 | 't' << 24);
+        *version = 2;
+        *queue_num_max = queue_size;
+    }
+
+    /*
+    Each queue in a device needs to implement these functions on how to actually send/recv data from the virtqueue
+    Sometimes we just get one descriptor that we need to fill in with data, the size of this descriptor is normally
+    header size + amount of data to fill. The logic for these kind of queues can be implemented using process_queue_start alone
+
+    Sometimes we need to fill in data across multiple desciptors, the first descriptor is of header size, and the next n descriptors
+    have the actual data filled in. The header gets processed by process_queue_start, the next n descriptors get processed by
+    process_queue_data
+
+    Sometimes the last descriptor is just of size 1 byte, normally used to store the status value of the read or write
+    That can be done using process_queue_complete
+    */
+    virtual void process_queue_start(int queue_idx, uint8_t* addr, uint64_t len) = 0;
+    virtual void process_queue_data(int queue_idx, uint8_t* addr, uint64_t len) = 0;
+    virtual void process_queue_complete(int queue_idx, uint8_t* addr, uint64_t len) = 0;
+    
+    // Each queue in a device can implement a custom "do I have data/should I process the queue method"
+    // For most devices/queues this isn't needed because we want to feed data into/read data from
+    // the queue as long as the tail of the queue is lagging behind the head
+    // But in some cases like  network devices, we want to wait till slirp has a packet ready for us
+    // so this is useful in cases like that
+    virtual bool queue_has_data(int queue_idx) = 0;
+
+    inline void ack_interrupt(){
+        /*
+        If driver has acknlowedged VIRTIO_MMIO_INT_VRING interrupt by setting bit 0 in interrupt_ack register
+        We unset the interrupt by writing 0 to the correct bit in interrupt_register
+        */
+        uint32_t interrupt_status_val = *interrupt_status;
+        uint32_t interrupt_ack_val = *interrupt_ack;
+        if ((interrupt_ack_val & 1)==1) {
+            *interrupt_status = ~VIRTIO_MMIO_INT_VRING & interrupt_status_val;
+            *interrupt_ack = ~1 & interrupt_ack_val;
+            std::lock_guard<std::mutex> guard(interrupt_register_lock);
+            *interrupt_register = *interrupt_register & ~(1 << (interrupt_number - 5));
+        }
+    }
+
+    inline void set_interrupt(){
+        /*
+        Set required bit in interrupt_register to 1 if we need to trigger an interrupt
+        */
+        uint32_t interrupt_status_val = *interrupt_status;
+        if (interrupt_status_val==0){
+            *interrupt_status = VIRTIO_MMIO_INT_VRING | interrupt_status_val;
+            std::lock_guard<std::mutex> guard(interrupt_register_lock);
+            /*
+            FIXME: setting multiple interrupts on the plic seems to be buggy
+            so we just set our interrupt instead
+            */
+            // *interrupt_register = *interrupt_register | (1 << (interrupt_number - 5));
+            *interrupt_register = (1 << (interrupt_number - 5));
+        }
+    }
+
+    void device_setup(){
+        /*
+        TODO: Draw a state transition diagram here maybe?
+        */
+        while (!exit_thread_flag) {
+            if (*status & VIRTIO_CONFIG_S_DRIVER) {
+                break;
+            }
+        }
+        while (!exit_thread_flag) {
+            *device_features = device_features_list[*device_features_sel];
+            // TODO: read driver_features and do negotiation?
+
+            if (*status & VIRTIO_CONFIG_S_FEATURES_OK) {
+                break;
+            }
+        }
+
+        // Resize vectors for queue pointers
+        desc.resize(num_queues, nullptr);
+        avail.resize(num_queues, nullptr);
+        used.resize(num_queues, nullptr);
+        descriptor_table_address.resize(num_queues, 0);
+        available_ring_address.resize(num_queues, 0);
+        used_ring_address.resize(num_queues, 0);
+
+        /*
+        Stage where we get virtqueue addresses from driver
+        This implementation is still buggy timing wise sometimes
+        We fail to get past this stage. Improve this
+        */
+        uint32_t prev_queue_select = -1;
+        while (!exit_thread_flag) {
+            uint32_t queue_select_val = *queue_select;
+            uint32_t queue_ready_val = *queue_ready;
+            *queue_ready = 0;
+
+            if (queue_ready_val && (queue_select_val != prev_queue_select)) {
+                descriptor_table_address[queue_select_val] = ((uint64_t)(*queue_desc_high) << 32) | (*queue_desc_low);
+                available_ring_address[queue_select_val] = ((uint64_t)(*queue_avail_high) << 32) | (*queue_avail_low);
+                used_ring_address[queue_select_val] = ((uint64_t)(*queue_used_high) << 32) | (*queue_used_low);
+                prev_queue_select = queue_select_val;
+                if (queue_select_val == (num_queues - 1))
+                    break;
+            }
+            usleep(1);
+        }
+        for (uint32_t i = 0; i < num_queues; i++) {
+            desc[i] = (struct vring_desc*) (memory + (descriptor_table_address[i] - starting_address));
+            avail[i] = (struct vring_avail*) (memory + (available_ring_address[i] - starting_address));
+            used[i] = (struct vring_used*) (memory + (used_ring_address[i] - starting_address));
+        }
+        while (!exit_thread_flag){
+            if (*status & VIRTIO_CONFIG_S_DRIVER_OK) {
+                break;
+            }
+        }
+    }
+
+    void device_loop(){
+        std::vector<uint16_t> processed(num_queues, 0);
+
+        while (!exit_thread_flag) {
+            if (*magic_value != ('v' | 'i' << 8 | 'r' << 16 | 't' << 24)) {
+                return;
+            }
+
+            // uint32_t queue_notify_val = *queue_notify;
+            // If any interrupts have been acked by device, unset interrupt on plic
+            ack_interrupt();
+
+            // Process each virtqueue
+            for(uint32_t queue_idx=0; queue_idx<num_queues; queue_idx++){
+                struct vring_desc *desc_q = desc[queue_idx];
+                struct vring_avail *avail_q = avail[queue_idx];
+                struct vring_used *used_q = used[queue_idx];
+                
+                // if (queue_notify_val == i) {
+                    __sync_synchronize();
+                    bool should_i_set_interrupt=false;
+                    uint16_t avail_idx = avail_q->idx;
+                    /*
+                    processed[i] represents the tail of the queue (our point of view)
+                    avail_idx represents the head of the queue (driver's point of view)
+                    */
+                    while (processed[queue_idx] != avail_idx && queue_has_data(queue_idx)) {
+                        should_i_set_interrupt=true;
+                        /*
+                        avail_q stores a list of descriptors for us to process
+                        We pick a desc_idx to process from the avail queue
+                        */
+                        uint16_t desc_idx = avail_q->ring[processed[queue_idx] % queue_size];
+                        uint16_t desc_idx_first = desc_idx;
+                        
+                        /*
+                        desc_idx points to an index of desc_q
+                        We either read or write data to that index in the descriptor queue
+                        */
+                        uint64_t num_bytes_written = 0;
+                        uint64_t l = desc_q[desc_idx % queue_size].len;
+                        uint64_t a = desc_q[desc_idx % queue_size].addr;
+                        uint8_t *addr = memory + (a - starting_address);;
+                        
+                        /*
+                        Sometimes we just process one entry in the desc_q
+                        Sometimes the entries have a next flag set 
+                        (desc_q[desc_idx].flags & VRING_DESC_F_NEXT)
+                        which means that we need to process multiple entries
+                        till we encounter an entry without that flag
+                        */
+                        while (true) {
+                            l = desc_q[desc_idx % queue_size].len;
+                            a = desc_q[desc_idx % queue_size].addr;
+                            addr = memory + (a - starting_address);
+                            
+                            if ((desc_q[desc_idx % queue_size].flags & VRING_DESC_F_NEXT)) {
+                                if (num_bytes_written < queue_header_size) {
+                                    process_queue_start(queue_idx, addr, l);
+                                } else {
+                                    process_queue_data(queue_idx, addr, l);
+                                }
+                                num_bytes_written += l;
+                                desc_idx = desc_q[desc_idx % queue_size].next;
+                            } else {
+                                process_queue_complete(queue_idx, addr, l);
+                                num_bytes_written += l;
+                                break;
+                            }
+                        }
+                        
+                        /*
+                        We then update the used queue to inform the driver
+                        that we've processed desc_idx_first in the descriptor queue
+                        */
+                        uint16_t used_idx = used_q->idx;
+                        used_q->ring[used_idx % queue_size].id = desc_idx_first;
+                        used_q->ring[used_idx % queue_size].len = num_bytes_written - queue_header_size;
+                        __sync_synchronize();
+                        used_q->idx = used_idx + 1;
+
+                        processed[queue_idx] += 1;
+                    }
+                    if (should_i_set_interrupt){
+                        // Set interrupt on plic if we processed atleast 1 descriptor
+                        set_interrupt();
+                    }
+                // }
+            }
+            usleep(1);
+        }
+    }
+    virtual ~VirtioDevice() = default;
+
+    
+};

--- a/console/virtiodevice.hpp
+++ b/console/virtiodevice.hpp
@@ -298,7 +298,7 @@ public:
                     processed[i] represents the tail of the queue (our point of view)
                     avail_idx represents the head of the queue (driver's point of view)
                     */
-                    while (processed[queue_idx] != avail_idx && queue_has_data(queue_idx)) {
+                    if (processed[queue_idx] != avail_idx && queue_has_data(queue_idx)) {
                         should_i_set_interrupt=true;
                         /*
                         avail_q stores a list of descriptors for us to process

--- a/console/virtiodevice.hpp
+++ b/console/virtiodevice.hpp
@@ -180,7 +180,7 @@ public:
             *interrupt_status = ~VIRTIO_MMIO_INT_VRING & interrupt_status_val;
             *interrupt_ack = ~1 & interrupt_ack_val;
             std::lock_guard<std::mutex> guard(interrupt_register_lock);
-            *interrupt_register = *interrupt_register & ~(1 << (interrupt_number - 5));
+            // *interrupt_register = *interrupt_register & ~(1 << (interrupt_number - 5));
         }
     }
 
@@ -189,7 +189,7 @@ public:
         Set required bit in interrupt_register to 1 if we need to trigger an interrupt
         */
         uint32_t interrupt_status_val = *interrupt_status;
-        if (interrupt_status_val==0){
+        if (true){
             *interrupt_status = VIRTIO_MMIO_INT_VRING | interrupt_status_val;
             std::lock_guard<std::mutex> guard(interrupt_register_lock);
             /*

--- a/user-data.yaml
+++ b/user-data.yaml
@@ -1,0 +1,40 @@
+#cloud-config
+hostname: tt-blackhole-0
+fqdn: tt-blackhole-0.local
+
+users:
+  - name: ttuser
+    gecos: Tenstorrent User
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: users, admin, sudo
+    shell: /bin/bash
+    lock_passwd: false
+    # Create default user with empty password. You might want to set your own.
+    passwd: ""
+    ssh_authorized_keys:
+      # Add your SSH authorized keys here 
+
+# Disallow password auth since we're creating the user with empty password
+ssh_pwauth: false
+
+# Configure eth0 for DHCP
+network:
+  version: 2
+  ethernets:
+    eth0:
+      dhcp4: true
+      optional: true
+
+#chpasswd:
+#  list: |
+#    ubuntu:ubuntu
+#  expire: false
+
+packages:
+  - net-tools
+  - htop
+
+runcmd:
+  - echo "Boot complete at $(date)" > /var/log/first-boot.log
+
+final_message: "The system is finally up, after $UPTIME seconds"

--- a/watch.expect
+++ b/watch.expect
@@ -1,0 +1,38 @@
+#!/usr/bin/expect -f
+
+# Set the string you want to search for
+set target_string "login:"
+
+# Set a timeout in seconds (e.g., 600 for 10 minutes).
+# If the string isn't found within this time, the script will exit.
+# Set to -1 for no timeout.
+set timeout 600
+
+# Command to run
+set command "make boot"
+
+# Prevent expect from echoing the spawned command's output
+log_user 0
+
+# Spawn the command
+eval spawn $command
+
+# Expect the target string
+expect {
+    timeout {
+        puts stderr "Timeout: '$target_string' not found within $timeout seconds."
+        # send -raw "\x01x"
+        exit 1
+    }
+    eof {
+        puts stderr "EOF: Command finished before '$target_string' was found."
+        # send -raw "\x01x"
+        exit 2
+    }
+    -re $target_string {
+        puts "Found target string: '$target_string'"
+        puts "Sending Ctrl+A, Ctrl+X to exit."
+        send -raw "\x01x"
+        exit 0
+    }
+}


### PR DESCRIPTION
Putting this up to get comments. Main changes are these

1. Adds a `VirtioDevice` class in `virtiodevice.hpp` that implements most of the generic functionality needed for emulating the device side of a virtio-mmio device for the x280

The main methods here are `device_setup()` (which is mostly device agnostic) and `device_loop()`. The latter makes calls to certain virtual functions for handling the actual data transfer. each device subclass needs to implement these functions.

2. Adds implementations of `VirtioBlk` in `disk.hpp` and `VirtioNet` in `network.hpp` that are derived from `VirtioDevice`
3. Some changes to `tt-bh-linux.cpp` to use these above implementations for network (instead of the previous custom implementation) and a boot disk
4. changes to boot.py to make rootfs optional 

This uses a custom kernel branch(https://github.com/asrinivasanTT/linux/tree/tt-blackhole-virtio). This adds in a bunch of sleeps to the setup stage of the virtio_mmio driver, and adds a 2 virtio devices (net and boot) to the `blackhole.dtsi` device tree. Also makes the boot disk `/dev/vda` instead of `/dev/pmem0`

You need to clean `rm -rf Image linux` and rebuild kernel `make build_linux` to test it out.

There are a lot of changes added here. 