### PR TITLE
Makefile: fix SESSION variable used for connect_all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,25 +93,25 @@ connect: _need_hosttool _need_ttkmd
 ssh:
 	ssh -F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o NoHostAuthenticationForLocalhost=yes -o User=debian -p2222 localhost
 
+SESSION = connect_all
 # Launch tmux with a 2x2 grid and connect to each l2cpu in each
 connect_all: _need_tmux
 	# Kill any existing sessions named connect_all
-	SESSION=connect_all
-	tmux has-session -t "$SESSION" 2>/dev/null && tmux kill-session -t "$SESSION" || true
+	tmux has-session -t "$(SESSION)" 2>/dev/null && tmux kill-session -t "$(SESSION)" || true
 
-	tmux new-session  -d -s "$SESSION" './console/tt-bh-linux --l2cpu 0' 	# pane 0
-	tmux split-window -h -t "$SESSION":0 './console/tt-bh-linux --l2cpu 1' 	# pane 1 (right)
-	tmux select-pane   -t "$SESSION":0.0 									# back to pane 0
-	tmux split-window -v -t "$SESSION":0 './console/tt-bh-linux --l2cpu 2' 	# pane 2 (bottom-left)
-	tmux select-pane   -t "$SESSION":0.1 									# go to pane 1
-	tmux split-window -v -t "$SESSION":0 './console/tt-bh-linux --l2cpu 3' 	# pane 3 (bottom-right)
-	tmux select-layout -t "$SESSION":0 tiled 								# ensure 2x2 grid
+	tmux new-session  -d -s "$(SESSION)" './console/tt-bh-linux --l2cpu 0' 	# pane 0
+	tmux split-window -h -t "$(SESSION)":0 './console/tt-bh-linux --l2cpu 1' 	# pane 1 (right)
+	tmux select-pane   -t "$(SESSION)":0.0 									# back to pane 0
+	tmux split-window -v -t "$(SESSION)":0 './console/tt-bh-linux --l2cpu 2' 	# pane 2 (bottom-left)
+	tmux select-pane   -t "$(SESSION)":0.1 									# go to pane 1
+	tmux split-window -v -t "$(SESSION)":0 './console/tt-bh-linux --l2cpu 3' 	# pane 3 (bottom-right)
+	tmux select-layout -t "$(SESSION)":0 tiled 								# ensure 2x2 grid
 
 	# If we're already inside a tmux session, we need to use switch-client
 	if [ -n "$$TMUX" ]; then \
-        tmux switch-client -t "$SESSION"; \
+        tmux switch-client -t "$(SESSION)"; \
     else \
-        tmux attach-session -t "$SESSION"; \
+        tmux attach-session -t "$(SESSION)"; \
     fi
 
 


### PR DESCRIPTION
Fix usage of SESSION variable so that the tmux commands actually use the string "connect_all" for the session.

Without this fix, I noticed in ps on the host:
```
tmux attach-session -t ESSION 
```
tmux was using `ESSION` as the session string instead of `connect_all`.