### PR TITLE
Fix release workflow for v0.3 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ jobs:
     needs: [build, generate_rootfs]
     permissions:
       contents: write
-    runs-on: tt-beta-ubuntu-2204-small
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ download_rootfs: _need_wget _need_unxz
 		exit 0; \
 	fi; \
 	set -x ; \
-	$(call wget,tt-bh-disk-image.zip,https://github.com/tenstorrent/tt-bh-linux/releases/download/v0.2/tt-bh-disk-image.zip)
+	$(call wget,tt-bh-disk-image.zip,https://github.com/tenstorrent/tt-bh-linux/releases/download/v0.3/tt-bh-disk-image.zip)
 	unzip tt-bh-disk-image.zip
 	rm tt-bh-disk-image.zip
 	mv debian-riscv64.img rootfs.ext4
@@ -303,7 +303,7 @@ download_rootfs: _need_wget _need_unxz
 # Download prebuilt Linux, opensbi and dtb
 download_prebuilt: _need_wget _need_unzip
 	# TODO: Test this once repo is public
-	$(call wget,tt-bh-linux.zip,https://github.com/tenstorrent/tt-bh-linux/releases/download/v0.2/tt-bh-linux.zip)
+	$(call wget,tt-bh-linux.zip,https://github.com/tenstorrent/tt-bh-linux/releases/download/v0.3/tt-bh-linux.zip)
 	unzip tt-bh-linux.zip
 	rm tt-bh-linux.zip
 


### PR DESCRIPTION
The github actions step that uploads release images was failing because the gh-cli was not installed on the TT hosted runner. So this job was moved to use the GH hosted runner instead.

Also, the makefile was updated to use artifacts from the v0.3 release/ 