### PR TITLE
Add ca-certificates to debian image

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -57,7 +57,7 @@ trap cleanup EXIT
 
 info "Installing system with debootstrap"
 mkdir -p $CACHE
-PACKAGES=sudo,openssh-server,systemd-timesyncd,vim,python3,make,gcc,libc6-dev,neowofetch,systemd-resolved,dbus,htop,ninvaders,git,wget
+PACKAGES=sudo,openssh-server,systemd-timesyncd,vim,python3,make,gcc,libc6-dev,neowofetch,systemd-resolved,dbus,htop,ninvaders,git,wget,ca-certificates
 debootstrap --cache-dir $CACHE --include $PACKAGES --arch riscv64 trixie $MOUNT http://deb.debian.org/debian
 
 info "Mounting filesystems"


### PR DESCRIPTION
https doesn't work properly in the debian image unless this is there