### PR TITLE
Improvents to virtio implementation

### DIFF
--- a/console/l2cpu.cpp
+++ b/console/l2cpu.cpp
@@ -52,8 +52,8 @@ L2CPU::L2CPU(int idx)
 
     memory = reinterpret_cast<uint8_t*>(mmap(nullptr, (2ULL<<32), PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
 
-    first = std::make_unique<TlbWindow4G>(fd, coordinates.x, coordinates.y, 0x4000'0000'0000ULL, memory);
-    second = std::make_unique<TlbWindow4G>(fd, coordinates.x, coordinates.y, 0x4001'0000'0000ULL, memory+(1ULL<<32));
+    first = std::make_unique<TlbWindow4G>(fd, coordinates.x, coordinates.y, 0x4000'0000'0000ULL, memory, true);
+    second = std::make_unique<TlbWindow4G>(fd, coordinates.x, coordinates.y, 0x4001'0000'0000ULL, memory+(1ULL<<32), true);
 }
 
 uint64_t L2CPU::get_starting_address(){

--- a/console/tlb.cpp
+++ b/console/tlb.cpp
@@ -5,7 +5,7 @@
 #include <sys/ioctl.h>
 #include "tlb.h"
 
-TlbHandle::TlbHandle(int fd, size_t size, const tenstorrent_noc_tlb_config &config, void* base)
+TlbHandle::TlbHandle(int fd, size_t size, const tenstorrent_noc_tlb_config &config, void* base, bool use_wc)
     : fd(fd)
     , tlb_size(size)
 {
@@ -29,7 +29,7 @@ TlbHandle::TlbHandle(int fd, size_t size, const tenstorrent_noc_tlb_config &conf
         exit(1);
     }
 
-    void *mem = mmap(base, size, PROT_READ | PROT_WRITE, base==nullptr? MAP_SHARED: MAP_SHARED | MAP_FIXED, fd, allocate_tlb.out.mmap_offset_uc);
+    void *mem = mmap(base, size, PROT_READ | PROT_WRITE, base==nullptr? MAP_SHARED: MAP_SHARED | MAP_FIXED, fd, use_wc? allocate_tlb.out.mmap_offset_wc: allocate_tlb.out.mmap_offset_uc);
     if (mem == MAP_FAILED) {
         tenstorrent_free_tlb free_tlb{};
         free_tlb.in.id = tlb_id;

--- a/console/tlb.h
+++ b/console/tlb.h
@@ -28,7 +28,7 @@ class TlbHandle
     size_t tlb_size;
 
 public:
-    TlbHandle(int fd, size_t size, const tenstorrent_noc_tlb_config &config, void* base=nullptr);
+    TlbHandle(int fd, size_t size, const tenstorrent_noc_tlb_config &config, void* base=nullptr, bool use_wc=false);
 
     uint8_t* data();
     size_t size() const;
@@ -47,7 +47,7 @@ class TlbWindow
     std::unique_ptr<TlbHandle> window;
 
 public:
-    TlbWindow(int fd, uint16_t x, uint16_t y, uint64_t addr, void* base=nullptr);
+    TlbWindow(int fd, uint16_t x, uint16_t y, uint64_t addr, void* base=nullptr, bool use_wc=false);
 
     void write32(uint64_t addr, uint32_t value);
 
@@ -57,7 +57,7 @@ public:
 };
 
 template <size_t WINDOW_SIZE>
-TlbWindow<WINDOW_SIZE>::TlbWindow(int fd, uint16_t x, uint16_t y, uint64_t addr, void* base)
+TlbWindow<WINDOW_SIZE>::TlbWindow(int fd, uint16_t x, uint16_t y, uint64_t addr, void* base, bool use_wc)
 : offset(addr & WINDOW_MASK)
 {
     tenstorrent_noc_tlb_config config{
@@ -66,7 +66,7 @@ TlbWindow<WINDOW_SIZE>::TlbWindow(int fd, uint16_t x, uint16_t y, uint64_t addr,
         .y_end = y,
     };
 
-    window = std::make_unique<TlbHandle>(fd, WINDOW_SIZE, config, base);
+    window = std::make_unique<TlbHandle>(fd, WINDOW_SIZE, config, base, use_wc);
 }
 
 

--- a/console/virtiodevice.hpp
+++ b/console/virtiodevice.hpp
@@ -110,7 +110,7 @@ public:
 
         // TODO: Check if (interrupt_number-5) is in valid 
         // range, and adjust which register to use accordingly
-        uint64_t interrupt_address = 0xFFFFF7FEFFF10000ULL + 0x404;
+        uint64_t interrupt_address = 0x2FF10000 + 0x404;
         interrupt_address_window = l2cpu.get_persistent_2M_tlb_window(interrupt_address);
         interrupt_register = reinterpret_cast<uint32_t*>(interrupt_address_window->get_window());
 


### PR DESCRIPTION
# List of Changes
1. Use WC (Write-combined) TLB for 4G TlbWindows used for "DMA" done by the virtio device

Previously, the "DMA" part for the virtio disk would take 10s of microseconds for disk reads (host->x280) and 1000s if microseconds for disk writes (x280->host). Now, the reads are in 1s of microseconds for reads and 100s of microseconds for writes. (these are rough numbers for 4k reads and write)

This makes the virtio disk very usable now.

Testing this command
```
time git clone -b tt-blackhole --depth 1 https://github.com/tenstorrent/linux
```
Before
```
real    16m39.421s
user    1m20.121s
sys     0m24.881s
```
After
```
real    1m43.284s
user    1m20.173s
sys     0m25.757s
```

All other accesses (to mmio regs of virtio device and interrupt register) still use uc TLB mappings

2. For accesses to the interrupts register, use it's address from the x280 physical address space (0x2FF10000 + 0x404) instead of the NOC visible high address space (0xFFFFF7FEFFF10000 + 0x404). ~~This might help avoiding any issues that come up because the x280 (which does the unsetting of the interrupt bit) and the host (which does the setting) see different values of this register because the x280 caches access to this register.~~ This statement is not true