### PR TITLE
console: Unset interrupt register bit immediately

### DIFF
--- a/console/virtiodevice.hpp
+++ b/console/virtiodevice.hpp
@@ -209,6 +209,8 @@ public:
             */
             // *interrupt_register = *interrupt_register | (1 << (interrupt_number - 5));
             *interrupt_register = (1 << (interrupt_number - 5));
+            __sync_synchronize();
+            *interrupt_register = 0;
         }
     }
 


### PR DESCRIPTION
After doing some testing here https://github.com/tenstorrent/tt-bh-linux/issues/116#issuecomment-3587744324, it seems like adding this change in would let us get rid of the changes to the PLIC's kernel driver.

I also have an updated `tt-blackhole-v6.18` branch of the kernel that doesn't have those changes. After some testing by few others, I will make `tt-blackhole` point to that and create a new release.