### PR TITLE
Add /sbin and /usr/sbin to $PATH for Debian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,15 @@ else
 	PYTHON := python3
 endif
 
+# Ensure /sbin and /usr/sbin are in PATH for tools like e2fsck, resize2fs
+ifeq (,$(findstring /sbin,$(PATH)))
+    PATH := $(PATH):/sbin
+endif
+ifeq (,$(findstring /usr/sbin,$(PATH)))
+    PATH := $(PATH):/usr/sbin
+endif
+export PATH
+
 # Default riscv64 disk image file. Change this to point at your local image
 # if you have one
 DISK_IMAGE := rootfs.ext4


### PR DESCRIPTION
Closes: #126 

Added `/sbin` and `/usr/sbin` to PATH to fix `e2fsck, resize2fs: command not found` error on Debian.

Tested on Debain 13 - `make download_all` now works without requiring manual PATH modification.