### PR TITLE
Fix missing backslash in .PHONY declaration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -441,7 +441,7 @@ endef
 
 .PHONY: apt_update \
 	boot \
-	boot_all
+	boot_all \
 	build_all \
 	build_hosttool \
 	build_linux \


### PR DESCRIPTION
Add missing backslash after boot_all in the `.PHONY` target list. Without this, the Makefile syntax is broken.