### PR TITLE
Makefile: Add NO_VIRTIO arg to skip patching DT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ SHELL := /bin/bash
 
 nproc := $(shell nproc)
 
+ifeq ($(NO_VIRTIO), 1)
+	DT_NO_VIRTIO_DEVICES := --dt_no_virtio_devices
+endif
+
 # Uncomment this to make the shell rules verbose
 # SHELL_VERBOSE := set -x ;
 
@@ -97,7 +101,7 @@ boot: _need_linux _need_opensbi _need_dtb _need_rootfs _need_hosttool _need_pyth
 
 # Boot one L2CPU in Blackhole RISC-V CPU into an initramfs specified by $(INITRAMFS)
 boot_initramfs: _need_linux _need_opensbi _need_dtb _need_rootfs _need_hosttool _need_python _need_luwen _need_ttkmd _need_pylibfdt
-	$(PYTHON) boot.py --boot --ttdevice $(TTDEVICE) --l2cpu $(L2CPU) --opensbi_bin fw_jump.bin --opensbi_dst 0x400030000000 --rootfs_dst 0x4000e5000000 --kernel_bin Image --kernel_dst 0x400030200000 --dtb_bin blackhole-card.dtb --dtb_dst 0x400030100000 --boot_device initramfs --rootfs_bin $(INITRAMFS)
+	$(PYTHON) boot.py --boot --ttdevice $(TTDEVICE) --l2cpu $(L2CPU) --opensbi_bin fw_jump.bin --opensbi_dst 0x400030000000 --rootfs_dst 0x4000e5000000 --kernel_bin Image --kernel_dst 0x400030200000 --dtb_bin blackhole-card.dtb --dtb_dst 0x400030100000 --boot_device initramfs --rootfs_bin $(INITRAMFS) $(DT_NO_VIRTIO_DEVICES)
 	./console/tt-bh-linux --ttdevice $(TTDEVICE) --l2cpu $(L2CPU) --disk $(DISK_IMAGE)
 
 # boot_all: _need_linux _need_opensbi _need_dtb _need_dtb_all _need_rootfs _need_hosttool _need_python _need_luwen _need_ttkmd _need_pylibfdt

--- a/boot.py
+++ b/boot.py
@@ -39,6 +39,7 @@ def parse_args():
 
     # If using FW_PAYLOAD, set these args for rootfs and opensbi
     parser.add_argument("--boot_device", type=str, required=False, default="vda", help="Options: vda, vdaX or initramfs")
+    parser.add_argument("--dt_no_virtio_devices", action="store_true", help="Don't patch DT to add virtio device nodes")
 
     # Only used for initramfs
     parser.add_argument("--rootfs_bin", type=str, required=False, help="Path to initramfs")
@@ -149,48 +150,49 @@ def main():
             print("memory node not found in DT. Exiting")
             exit(1)
 
-        mem = fdt.getprop(memory_node, "reg")
-        mem_start, mem_size = struct.unpack('>QQ', mem)
-        mem_end = mem_start + mem_size
+        if not args.dt_no_virtio_devices:
+            mem = fdt.getprop(memory_node, "reg")
+            mem_start, mem_size = struct.unpack('>QQ', mem)
+            mem_end = mem_start + mem_size
 
-        reserved_memory_offset = fdt.path_offset("/reserved-memory", libfdt.QUIET_NOTFOUND)
-        if reserved_memory_offset < 0:
-            reserved_memory_offset = fdt.add_subnode(0, "reserved-memory")
-            fdt.setprop_u32(reserved_memory_offset, "#address-cells", 2)
-            fdt.setprop_u32(reserved_memory_offset, "#size-cells", 2)
-            fdt.setprop(reserved_memory_offset, "ranges", b'')
+            reserved_memory_offset = fdt.path_offset("/reserved-memory", libfdt.QUIET_NOTFOUND)
+            if reserved_memory_offset < 0:
+                reserved_memory_offset = fdt.add_subnode(0, "reserved-memory")
+                fdt.setprop_u32(reserved_memory_offset, "#address-cells", 2)
+                fdt.setprop_u32(reserved_memory_offset, "#size-cells", 2)
+                fdt.setprop(reserved_memory_offset, "ranges", b'')
 
-        virtio_reserved_offset = fdt.add_subnode(reserved_memory_offset, "memory@4000afa00000")
-        reserved_reg = struct.pack('>QQ', mem_end - 0x600000, 0x600000)
-        fdt.setprop(virtio_reserved_offset, "reg", reserved_reg)
-        fdt.setprop(virtio_reserved_offset, "no-map", b'')
+            virtio_reserved_offset = fdt.add_subnode(reserved_memory_offset, "memory@4000afa00000")
+            reserved_reg = struct.pack('>QQ', mem_end - 0x600000, 0x600000)
+            fdt.setprop(virtio_reserved_offset, "reg", reserved_reg)
+            fdt.setprop(virtio_reserved_offset, "no-map", b'')
 
-        soc_offset = fdt.path_offset("/soc", libfdt.QUIET_NOTFOUND)
-        if soc_offset < 0:
-            print("soc node not found in DT. Exiting")
-            exit(1)
+            soc_offset = fdt.path_offset("/soc", libfdt.QUIET_NOTFOUND)
+            if soc_offset < 0:
+                print("soc node not found in DT. Exiting")
+                exit(1)
 
-        plic_offset = fdt.path_offset("/soc/interrupt-controller@c000000", libfdt.QUIET_NOTFOUND)
-        if plic_offset < 0:
-            print("plic node not found in DT. Exiting")
-            exit(1)
+            plic_offset = fdt.path_offset("/soc/interrupt-controller@c000000", libfdt.QUIET_NOTFOUND)
+            if plic_offset < 0:
+                print("plic node not found in DT. Exiting")
+                exit(1)
 
-        plic_phandle = fdt.get_phandle(plic_offset)
-        if plic_phandle == 0:
-            # PLIC node doesn't have a phandle, create a unique one
-            plic_phandle = libfdt.fdt_get_max_phandle(fdt._fdt) + 1
-            fdt.setprop_u32(plic_offset, "phandle", plic_phandle)
+            plic_phandle = fdt.get_phandle(plic_offset)
+            if plic_phandle == 0:
+                # PLIC node doesn't have a phandle, create a unique one
+                plic_phandle = libfdt.fdt_get_max_phandle(fdt._fdt) + 1
+                fdt.setprop_u32(plic_offset, "phandle", plic_phandle)
 
-        for i in range(3, -1, -1):
-            virtio_addr = mem_end - 0x200000 * (i + 1)
-            virtio_irq = 33 - i
+            for i in range(3, -1, -1):
+                virtio_addr = mem_end - 0x200000 * (i + 1)
+                virtio_irq = 33 - i
 
-            virtio_offset = fdt.add_subnode(soc_offset, f"virtio@{virtio_addr:x}")
-            fdt.setprop_str(virtio_offset, "compatible", "virtio,mmio")
-            virtio_reg = struct.pack('>QQ', virtio_addr, 0x200000)
-            fdt.setprop(virtio_offset, "reg", virtio_reg)
-            fdt.setprop_u32(virtio_offset, "interrupts", virtio_irq)
-            fdt.setprop_u32(virtio_offset, "interrupt-parent", plic_phandle)
+                virtio_offset = fdt.add_subnode(soc_offset, f"virtio@{virtio_addr:x}")
+                fdt.setprop_str(virtio_offset, "compatible", "virtio,mmio")
+                virtio_reg = struct.pack('>QQ', virtio_addr, 0x200000)
+                fdt.setprop(virtio_offset, "reg", virtio_reg)
+                fdt.setprop_u32(virtio_offset, "interrupts", virtio_irq)
+                fdt.setprop_u32(virtio_offset, "interrupt-parent", plic_phandle)
 
         fdt.pack()
         dtb_bytes = fdt._fdt


### PR DESCRIPTION
When running boot_initramfs, we might sometimes not care/want the virtio devices to be added to the DT (if we want to test a pure upstream configuration of kernel/DTB). boot.py adds these nodes to the DT automatically. Add a makefile arg to prevent this.