### PR TITLE
boot.py: Fix import errors with newer tt-smi

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -9,9 +9,14 @@ try:
     # Luwen pre-v4.2.0
     from tt_smi.tt_smi_backend import pci_board_reset
 except ImportError:
-    # v4.2.0 onwards
-    from tt_smi.tt_smi_reset import pci_board_reset
-    from tt_smi.tt_smi_reset import pci_board_reset, parse_reset_input
+    try:
+        # v4.2.0 onwards
+        from tt_smi.tt_smi_reset import pci_board_reset, parse_reset_input
+    except ImportError:
+        # v5.2.0 onwards
+        from tt_smi.reset import pci_board_reset
+        from tt_smi.device_input import parse_smi_device_input as parse_reset_input
+
 import clock
 import time
 import libfdt


### PR DESCRIPTION
Some module and function names have changed in newer tt-smi versions leading to:

    mpe@rvsw-bh-03:~/tt-bh-linux$ make boot
    /home/mpe/.tenstorrent-venv/bin/python boot.py --boot --ttdevice 0
    --l2cpu 0 --opensbi_bin fw_jump.bin --opensbi_dst 0x400030000000
    --rootfs_dst 0x4000e5000000 --kernel_bin Image --kernel_dst
    0x400030200000 --dtb_bin blackhole-card.dtb --dtb_dst 0x400030100000
    Traceback (most recent call last):
      File "/home/mpe/tt-bh-linux/boot.py", line 10, in <module>
        from tt_smi.tt_smi_backend import pci_board_reset
    ModuleNotFoundError: No module named 'tt_smi.tt_smi_backend'

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/home/mpe/tt-bh-linux/boot.py", line 13, in <module>
        from tt_smi.tt_smi_reset import pci_board_reset
    ModuleNotFoundError: No module named 'tt_smi.tt_smi_reset'
    make: *** [Makefile:114: boot] Error 1

Add another try block to use the new names if the old names are not found.

Related tt-smi commits:

https://github.com/tenstorrent/tt-smi/commit/1a66172340d2201753fc6c0d15a3cbdb3782acea
https://github.com/tenstorrent/tt-smi/commit/982fd81d05aa71d188dcc5dcb09d5625790f1969