### PR TITLE
Fixes to run on systems with no Bar4/4G TLBs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,19 +112,19 @@ help:
 # Boot one L2CPU in Blackhole RISC-V CPU
 boot: _need_linux _need_opensbi _need_dtb _need_rootfs _need_hosttool _need_python _need_luwen _need_ttkmd _need_pylibfdt
 	$(PYTHON) boot.py --boot --ttdevice $(TTDEVICE) --l2cpu $(L2CPU) --opensbi_bin $(OPENSBI) --opensbi_dst 0x400030000000 --rootfs_dst 0x4000e5000000 --kernel_bin $(KERNEL) --kernel_dst 0x400030200000 --dtb_bin $(DTB) --dtb_dst 0x400030100000
-	./console/tt-bh-linux --ttdevice $(TTDEVICE) --l2cpu $(L2CPU) --disk $(DISK_IMAGE)
+	./console/tt-bh-linux --ttdevice $(TTDEVICE) --l2cpu $(L2CPU) --disk $(DISK_IMAGE) --network
 
 # Boot one L2CPU in Blackhole RISC-V CPU into an initramfs specified by $(INITRAMFS)
 boot_initramfs: _need_linux _need_opensbi _need_dtb _need_rootfs _need_hosttool _need_python _need_luwen _need_ttkmd _need_pylibfdt
 	$(PYTHON) boot.py --boot --ttdevice $(TTDEVICE) --l2cpu $(L2CPU) --opensbi_bin $(OPENSBI) --opensbi_dst 0x400030000000 --rootfs_dst 0x4000e5000000 --kernel_bin $(KERNEL) --kernel_dst 0x400030200000 --dtb_bin $(DTB) --dtb_dst 0x400030100000 --boot_device initramfs --rootfs_bin $(INITRAMFS) $(DT_NO_VIRTIO_DEVICES) $(EXTRA_BOOTARGS)
-	./console/tt-bh-linux --ttdevice $(TTDEVICE) --l2cpu $(L2CPU) --disk $(DISK_IMAGE)
+	./console/tt-bh-linux --ttdevice $(TTDEVICE) --l2cpu $(L2CPU) --disk $(DISK_IMAGE) --network
 
 # boot_all: _need_linux _need_opensbi _need_dtb _need_dtb_all _need_rootfs _need_hosttool _need_python _need_luwen _need_ttkmd _need_pylibfdt
 # 	$(PYTHON) boot.py --boot --ttdevice $(TTDEVICE) --l2cpu 0 1 2 3 --opensbi_bin fw_jump.bin --opensbi_dst 0x400100000000 0x400100000000 0x400100000000 0x400180000000 --rootfs_dst 0x400165000000 0x400165000000 0x400165000000 0x4001e5000000 --kernel_bin Image --kernel_dst 0x400100200000 0x400100200000 0x400100200000 0x400180200000 --dtb_bin blackhole-card.dtb blackhole-card.dtb blackhole-card2.dtb blackhole-card3.dtb --dtb_dst 0x400100100000 0x400100100000 0x400100100000 0x400180100000 --boot_device initramfs --rootfs_bin $(INITRAMFS)
 
 # Connect to console (requires a booted RISC-V)
 connect: _need_hosttool _need_ttkmd
-	./console/tt-bh-linux --ttdevice $(TTDEVICE) --l2cpu $(L2CPU) --disk $(DISK_IMAGE)
+	./console/tt-bh-linux --ttdevice $(TTDEVICE) --l2cpu $(L2CPU) --disk $(DISK_IMAGE) --network
 
 # Connect over SSH (requires a booted RISC-V)
 ssh:
@@ -157,7 +157,7 @@ user-data.img: user-data.yaml _need_cloud_image_utils
 # Boot with cloud-init image attached
 boot_cloud_init: _need_linux _need_opensbi _need_dtb _need_rootfs _need_hosttool _need_python _need_luwen _need_ttkmd _need_pylibfdt user-data.img
 	$(PYTHON) boot.py --boot --ttdevice $(TTDEVICE) --l2cpu $(L2CPU) --opensbi_bin $(OPENSBI) --opensbi_dst 0x400030000000 --rootfs_dst 0x4000e5000000 --kernel_bin $(KERNEL) --kernel_dst 0x400030200000 --dtb_bin $(DTB) --dtb_dst 0x400030100000
-	./console/tt-bh-linux --ttdevice $(TTDEVICE) --l2cpu $(L2CPU) --disk $(DISK_IMAGE) --cloud-init user-data.img
+	./console/tt-bh-linux --ttdevice $(TTDEVICE) --l2cpu $(L2CPU) --disk $(DISK_IMAGE) --cloud-init user-data.img --network
 
 #################################
 # Recipes that build things

--- a/Makefile
+++ b/Makefile
@@ -136,12 +136,12 @@ ssh:
 # 	# Kill any existing sessions named connect_all
 # 	tmux has-session -t "$(SESSION)" 2>/dev/null && tmux kill-session -t "$(SESSION)" || true
 
-# 	tmux new-session  -d -s "$(SESSION)" './console/tt-bh-linux --ttdevice $(TTDEVICE) --l2cpu 0' 	# pane 0
-# 	tmux split-window -h -t "$(SESSION)":0 './console/tt-bh-linux --ttdevice $(TTDEVICE) --l2cpu 1' 	# pane 1 (right)
+# 	tmux new-session  -d -s "$(SESSION)" './console/tt-bh-linux --ttdevice $(TTDEVICE) --l2cpu 0 --disk $(DISK_IMAGE)' 	# pane 0
+# 	tmux split-window -h -t "$(SESSION)":0 './console/tt-bh-linux --ttdevice $(TTDEVICE) --l2cpu 1 --disk $(DISK_IMAGE)' 	# pane 1 (right)
 # 	tmux select-pane   -t "$(SESSION)":0.0 									# back to pane 0
-# 	tmux split-window -v -t "$(SESSION)":0 './console/tt-bh-linux --ttdevice $(TTDEVICE) --l2cpu 2' 	# pane 2 (bottom-left)
+# 	tmux split-window -v -t "$(SESSION)":0 './console/tt-bh-linux --ttdevice $(TTDEVICE) --l2cpu 2 --disk $(DISK_IMAGE)' 	# pane 2 (bottom-left)
 # 	tmux select-pane   -t "$(SESSION)":0.1 									# go to pane 1
-# 	tmux split-window -v -t "$(SESSION)":0 './console/tt-bh-linux --ttdevice $(TTDEVICE) --l2cpu 3' 	# pane 3 (bottom-right)
+# 	tmux split-window -v -t "$(SESSION)":0 './console/tt-bh-linux --ttdevice $(TTDEVICE) --l2cpu 3 --disk $(DISK_IMAGE)' 	# pane 3 (bottom-right)
 # 	tmux select-layout -t "$(SESSION)":0 tiled 								# ensure 2x2 grid
 
 # 	# If we're already inside a tmux session, we need to use switch-client

--- a/console/l2cpu.cpp
+++ b/console/l2cpu.cpp
@@ -3,7 +3,9 @@
 
 #include <fcntl.h>
 #include <cassert>
+#include <iostream>
 #include <sstream>
+#include <stdexcept>
 #include <sys/mman.h>
 #include <time.h>
 #include "l2cpu.h"
@@ -55,10 +57,29 @@ L2CPU::L2CPU(int idx, int card_idx)
     coordinates = l2cpu_tile_mapping.at(idx);
     memory_size = l2cpu_memory_size_mapping.at(idx);
 
-    memory = reinterpret_cast<uint8_t*>(mmap(nullptr, (2ULL<<32), PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    // Try to map the two 4G memory windows; if either fails, warn and continue
+    // without them instead of crashing.
+    try {
+        memory = reinterpret_cast<uint8_t*>(mmap(nullptr, (2ULL<<32), PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+        if (memory == MAP_FAILED) {
+            memory = nullptr;
+            throw std::runtime_error("mmap of 8G L2CPU memory region failed");
+        }
 
-    first = std::make_unique<TlbWindow4G>(fd, coordinates.x, coordinates.y, 0x4000'0000'0000ULL, memory, true);
-    second = std::make_unique<TlbWindow4G>(fd, coordinates.x, coordinates.y, 0x4001'0000'0000ULL, memory+(1ULL<<32), true);
+        first = std::make_unique<TlbWindow4G>(fd, coordinates.x, coordinates.y, 0x4000'0000'0000ULL, memory, true);
+        second = std::make_unique<TlbWindow4G>(fd, coordinates.x, coordinates.y, 0x4001'0000'0000ULL, memory+(1ULL<<32), true);
+    } catch (const std::exception &e) {
+        std::cerr << "Warning: could not allocate first/second TLB windows for L2CPU " << idx
+                  << ": " << e.what() << "\nContinuing without them. Virtio functionality won't work." << std::endl;
+
+        // Unwind anything that did succeed
+        second.reset();
+        first.reset();
+        if (memory != nullptr) {
+            munmap(memory, 2ULL<<32);
+            memory = nullptr;
+        }
+    }
 }
 
 uint64_t L2CPU::get_starting_address(){
@@ -98,6 +119,9 @@ std::unique_ptr<TlbWindow2M> L2CPU::get_persistent_2M_tlb_window(uint64_t addr){
 
 // Returns the starting address of the L2CPU's memory
 uint8_t* L2CPU::get_memory_ptr(){
+    if (memory == nullptr) {
+        return nullptr;  // 4G windows were never mapped
+    }
     return memory+(starting_address-0x4000'0000'0000ULL);
 }
 
@@ -176,7 +200,9 @@ void L2CPU::set_frequency(){
 
 L2CPU::~L2CPU() noexcept
 {
-    munmap(memory, 2ULL<<32);
+    if (memory != nullptr) {
+        munmap(memory, 2ULL<<32);
+    }
     close(fd);
 }
 

--- a/console/l2cpu.h
+++ b/console/l2cpu.h
@@ -22,7 +22,8 @@ class L2CPU
     // ptrs to first (0x4000'0000'0000) and second (0x4001'0000'0000) memory regions of L2CPU memory
     std::unique_ptr<TlbWindow4G> first, second;
     // ptr to 8G region that has the above 2 regions stacked together
-    uint8_t *memory;
+    // (nullptr if the first/second window allocation failed)
+    uint8_t *memory = nullptr;
 
     xy_t coordinates;
 

--- a/console/l2cpu.h
+++ b/console/l2cpu.h
@@ -3,6 +3,7 @@
 
 #ifndef L2CPU_H
 #define L2CPU_H
+#include <cstdint>
 #include <vector>
 #include <memory>
 #include <map>

--- a/console/tlb.cpp
+++ b/console/tlb.cpp
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cerrno>
+#include <cstring>
+#include <stdexcept>
 #include <sys/mman.h>
 #include <sys/ioctl.h>
 #include "tlb.h"
@@ -12,8 +15,7 @@ TlbHandle::TlbHandle(int fd, size_t size, const tenstorrent_noc_tlb_config &conf
     tenstorrent_allocate_tlb allocate_tlb{};
     allocate_tlb.in.size = size;
     if (ioctl(fd, TENSTORRENT_IOCTL_ALLOCATE_TLB, &allocate_tlb) != 0){
-        std::cerr<<"Failed to allocate TLB";
-        exit(1);
+        throw std::runtime_error("Failed to allocate TLB: " + std::string(strerror(errno)));
     }
 
     tlb_id = allocate_tlb.out.id;
@@ -25,8 +27,7 @@ TlbHandle::TlbHandle(int fd, size_t size, const tenstorrent_noc_tlb_config &conf
         tenstorrent_free_tlb free_tlb{};
         free_tlb.in.id = tlb_id;
         ioctl(fd, TENSTORRENT_IOCTL_FREE_TLB, &free_tlb);
-        std::cerr<<"Failed to configure TLB";
-        exit(1);
+        throw std::runtime_error("Failed to configure TLB: " + std::string(strerror(errno)));
     }
 
     void *mem = mmap(base, size, PROT_READ | PROT_WRITE, base==nullptr? MAP_SHARED: MAP_SHARED | MAP_FIXED, fd, use_wc? allocate_tlb.out.mmap_offset_wc: allocate_tlb.out.mmap_offset_uc);
@@ -34,8 +35,7 @@ TlbHandle::TlbHandle(int fd, size_t size, const tenstorrent_noc_tlb_config &conf
         tenstorrent_free_tlb free_tlb{};
         free_tlb.in.id = tlb_id;
         ioctl(fd, TENSTORRENT_IOCTL_FREE_TLB, &free_tlb);
-        std::cerr<<"Failed to map TLB";
-        exit(1);
+        throw std::runtime_error("Failed to map TLB: " + std::string(strerror(errno)));
     }
 
     tlb_base = reinterpret_cast<uint8_t *>(mem);

--- a/console/tlb.h
+++ b/console/tlb.h
@@ -4,6 +4,7 @@
 #ifndef TLB_H
 #define TLB_H
 #include <unistd.h>
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <cassert>

--- a/console/tt-bh-linux.cpp
+++ b/console/tt-bh-linux.cpp
@@ -54,7 +54,7 @@ void network_main(int ttdevice, int l2cpu, std::mutex& interrupt_register_lock, 
 
 int main(int argc, char **argv){
     int l2cpu=0;
-    std::string disk_image_path = "rootfs.ext4";
+    std::string disk_image_path = "";
     std::string cloud_init_path = "";
     int ttdevice = 0;
 
@@ -109,7 +109,9 @@ int main(int argc, char **argv){
 
   std::vector<std::thread> threads;
   threads.emplace_back(console_main, ttdevice,  l2cpu);
-  threads.emplace_back(disk_main, ttdevice, l2cpu, std::ref(interrupt_register_lock), 33, 2ULL*1024*1024, disk_image_path);
+  if (!disk_image_path.empty()) {
+    threads.emplace_back(disk_main, ttdevice, l2cpu, std::ref(interrupt_register_lock), 33, 2ULL*1024*1024, disk_image_path);
+  }
   threads.emplace_back(network_main, ttdevice, l2cpu, std::ref(interrupt_register_lock), 32, 4ULL*1024*1024);
   if (!cloud_init_path.empty()) {
     threads.emplace_back(disk_main, ttdevice, l2cpu, std::ref(interrupt_register_lock), 31, 6ULL*1024*1024, cloud_init_path);

--- a/console/tt-bh-linux.cpp
+++ b/console/tt-bh-linux.cpp
@@ -56,14 +56,16 @@ int main(int argc, char **argv){
     int l2cpu=0;
     std::string disk_image_path = "";
     std::string cloud_init_path = "";
+    bool enable_network = false;
     int ttdevice = 0;
 
-    const char* const short_opts = "t:l:d:c:h";
+    const char* const short_opts = "t:l:d:c:nh";
     const option long_opts[] = {
             {"ttdevice", required_argument, nullptr, 't'},
             {"l2cpu", required_argument, nullptr, 'l'},
             {"disk", required_argument, nullptr, 'd'},
             {"cloud-init", required_argument, nullptr, 'c'},
+            {"network", no_argument, nullptr, 'n'},
             {"help", no_argument, nullptr, 'h'},
             {nullptr, no_argument, nullptr, 0}
     };
@@ -89,14 +91,19 @@ int main(int argc, char **argv){
         case 'c': // Handle cloud init option
             cloud_init_path = optarg;
             break;
+        case 'n': // Enable virtio-net networking
+            enable_network = true;
+            break;
         case 'h': // -h or --help
         case '?': // Unrecognized option
         default:
             std::cout <<
-            "--l2cpu <l>:         L2CPU to attach to\n"
-            "--disk <path>:       Path to the disk image (default: rootfs.ext4)\n"
-            "--cloud-init <path>:   Path to the cloud-init image (optional)\n"
-            "--help:              Show help\n";
+            "--ttdevice <t>:        Tenstorrent device index (default: 0)\n"
+            "--l2cpu <l>:           L2CPU to attach to\n"
+            "--disk <path>:         Path to the disk image (enables virtio-blk)\n"
+            "--cloud-init <path>:   Path to the cloud-init image (enables virtio-blk for it)\n"
+            "--network:             Enable virtio-net networking via slirp\n"
+            "--help:                Show help\n";
             exit(1);
         }
     }
@@ -112,7 +119,9 @@ int main(int argc, char **argv){
   if (!disk_image_path.empty()) {
     threads.emplace_back(disk_main, ttdevice, l2cpu, std::ref(interrupt_register_lock), 33, 2ULL*1024*1024, disk_image_path);
   }
-  threads.emplace_back(network_main, ttdevice, l2cpu, std::ref(interrupt_register_lock), 32, 4ULL*1024*1024);
+  if (enable_network) {
+    threads.emplace_back(network_main, ttdevice, l2cpu, std::ref(interrupt_register_lock), 32, 4ULL*1024*1024);
+  }
   if (!cloud_init_path.empty()) {
     threads.emplace_back(disk_main, ttdevice, l2cpu, std::ref(interrupt_register_lock), 31, 6ULL*1024*1024, cloud_init_path);
   }


### PR DESCRIPTION
Misc fixes to allow tt-bh-linux to run without virtio on systems where Bar4 isn't available for various reasons.

User an call boot_initramfs, after editing the Makefile to drop the --disk and --network args in it. Console alone should work.