### PR TITLE
console: Print error about missing 4G TLBs in virtiodevice.cpp instead

### DIFF
--- a/console/l2cpu.cpp
+++ b/console/l2cpu.cpp
@@ -69,9 +69,7 @@ L2CPU::L2CPU(int idx, int card_idx)
         first = std::make_unique<TlbWindow4G>(fd, coordinates.x, coordinates.y, 0x4000'0000'0000ULL, memory, true);
         second = std::make_unique<TlbWindow4G>(fd, coordinates.x, coordinates.y, 0x4001'0000'0000ULL, memory+(1ULL<<32), true);
     } catch (const std::exception &e) {
-        std::cerr << "Warning: could not allocate first/second TLB windows for L2CPU " << idx
-                  << ": " << e.what() << "\nContinuing without them. Virtio functionality won't work." << std::endl;
-
+        // Virtio code errors out later via get_memory_ptr() == nullptr
         // Unwind anything that did succeed
         second.reset();
         first.reset();

--- a/console/virtiodevice.hpp
+++ b/console/virtiodevice.hpp
@@ -109,6 +109,11 @@ public:
         mmio_base = reinterpret_cast<uint8_t*>(window->get_window());
 
         memory = l2cpu.get_memory_ptr();
+        if (memory == nullptr) {
+            fprintf(stderr, "Error: L2CPU 4G TLB windows unavailable (get_memory_ptr returned null).\n"
+                    "Virtio cannot run without DRAM access; check TLB allocation (dmesg) and TLB availability after reset.\n");
+            exit(1);
+        }
 
         // TODO: Check if (interrupt_number-5) is in valid 
         // range, and adjust which register to use accordingly


### PR DESCRIPTION
This is where these TLBs actually get used, so let's print the error here instead.